### PR TITLE
Task/wa 29 fix special characters compress app

### DIFF
--- a/applications/compress/README.md
+++ b/applications/compress/README.md
@@ -1,6 +1,6 @@
 ## Compress app
 
-# 07/28/2023
+### 07/28/2023
 - The current fix utilizes the regex validator in the `app.json` to limit inputs of special characters.
 - The first input of `run.sh` file is the compression type. The rest of the arguments (with the use of `"$*"`) is taken as the archive file name.
 - Special characters are replaced by underscores.

--- a/applications/compress/README.md
+++ b/applications/compress/README.md
@@ -1,0 +1,8 @@
+## Compress app
+
+# 07/28/2023
+- The current fix utilizes the regex validator in the `app.json` to limit inputs of special characters.
+- The first input of `run.sh` file is the compression type. The rest of the arguments (with the use of `"$*"`) is taken as the archive file name.
+- Special characters are replaced by underscores.
+- Most of the special characters works fine if they are inside single quotes in the input field.
+- Some characters do not work when they are not inside quotes such as `& ;` since these characters have unique meaning in command line.

--- a/applications/compress/app.json
+++ b/applications/compress/app.json
@@ -1,6 +1,6 @@
 {
     "id": "compress",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Compress a file or folder for download.",
     "owner": "${apiUserId}",
     "enabled": true,
@@ -9,7 +9,7 @@
     "runtimeOptions": [
         "SINGULARITY_RUN"
     ],
-    "containerImage": "docker://taccaci/compress:latest",
+    "containerImage": "docker://taccaci/compress:0.0.2",
     "jobType": "BATCH",
     "maxJobs": -1,
     "maxJobsPerUser": -1,
@@ -49,9 +49,15 @@
                 },
                 {
                     "name": "Archive File Name",
-                    "description": "Output archive file name. The selected Compression Type will be appended to this filename.",
+                    "description": "Output archive file name. The selected Compression Type will be appended to this filename. Keep the file name inside single quotes. Any special characters in the file name will be replaced with an underscore.",
                     "inputMode": "REQUIRED",
-                    "arg": "Archive"
+                    "arg": "Archive",
+                    "notes": {
+                        "validator": {
+                            "regex": "^[a-zA-Z0-9!@#%^*-_.,'? ]+$",
+                            "message": "Must contain valid characters (a-z, A-Z, 0-9, !@#%^*-_.,?) and spaces."
+                        }
+                    }
                 }
             ],
             "containerArgs": [],

--- a/applications/compress/run.sh
+++ b/applications/compress/run.sh
@@ -2,17 +2,36 @@
 
 CTYPE=$1
 echo "Compression Type is ${CTYPE}"
+shift # the first argument is the compression type, so we shift it off the list
 
-ARCHIVE_FILE_NAME=$2
+ARCHIVE_FILE_NAME="$*" # the rest of the arguments are the file names to compress
+
+replace_special_chars() {
+  local string="$1"
+  local pattern='[!@# $%^*()?":<>{}`]'
+
+  if [[ $string =~ $pattern ]]; then
+    local replacement="_"
+    local sanitized_string=$(echo "$string" | sed 's/[!@# $%^*()?":<>{}`]/'"$replacement"'/g')
+    echo "$sanitized_string"
+  else
+    local sanitized_string=$string
+    echo "$sanitized_string"
+  fi
+}
 
 cd $_tapisExecSystemInputDir
 
+modified_archive_file_name=$(replace_special_chars "$ARCHIVE_FILE_NAME")
+
+echo $modified_archive_file_name
+
 if [ "$CTYPE" = "tgz" ]; then
   echo 'tarring'
-  tar czvf "${_tapisExecSystemOutputDir}/$ARCHIVE_FILE_NAME.tar.gz" .
+  tar -czvf "${_tapisExecSystemOutputDir}/$modified_archive_file_name.tar.gz" .
 else
   echo 'zipping'
-  zip "${_tapisExecSystemOutputDir}/$ARCHIVE_FILE_NAME.zip" ./*
+  zip "${_tapisExecSystemOutputDir}/$modified_archive_file_name.zip" ./*
 fi
 
 if [ ! $? ]; then


### PR DESCRIPTION
- Regex to limit input characters in app.json file.
- Replacing special characters in run.sh file.
- Instead of taking the second argument (i.e. "$2") as the input file name, the arguments (except the first one) are considered (i.e. "$*").