### PR TITLE
Task WA-33 PyReconstruct 0.0.1 Tapis V3 app

### DIFF
--- a/applications/pyreconstruct/Dockerfile
+++ b/applications/pyreconstruct/Dockerfile
@@ -1,0 +1,20 @@
+### use pyreconstruct image ###
+FROM tiffhuff/pyreconstruct:0.0.1
+# File copy is needed to avoid these from getting overwritten by bind mounts.
+# Bind mounts are needed for setting up interactive session (tools like dcv)
+RUN cp /lib/x86_64-linux-gnu/libm.so.6 /usr/local/bin/../lib/libm.so.6 && \
+  cp /lib/x86_64-linux-gnu/libpthread.so.0 /usr/local/bin/../lib/libpthread.so.0  && \
+  cp /lib/x86_64-linux-gnu/libc.so.6 /usr/local/bin/../lib/libc.so.6 && \
+  cp /lib/x86_64-linux-gnu/libdl.so.2 /usr/local/bin/../lib/libdl.so.2 && \
+  cp /lib/x86_64-linux-gnu/libutil.so.1 /usr/local/bin/../lib/libutil.so.1 && \
+  cp /lib64/ld-linux-x86-64.so.2 /usr/local/bin/../lib/ld-linux-x86-64.so.2 && \
+  cp /lib/x86_64-linux-gnu/librt.so.1 /usr/local/bin/../lib/librt.so.1 && \
+  cp /lib/x86_64-linux-gnu/libbz2.so.1.0 /usr/local/bin/../lib/libbz2.so.1.0
+
+COPY --from=taccaci/interactive-base:1.1.0 /tapis /tapis
+COPY wrapper.sh /app/wrapper.sh
+RUN chmod +x /app/wrapper.sh
+
+ENTRYPOINT [ "/tapis/run.sh" ]
+
+CMD ["1280x800"]

--- a/applications/pyreconstruct/README.md
+++ b/applications/pyreconstruct/README.md
@@ -1,0 +1,10 @@
+# PyReconstruct Tapis V3 app
+
+## Details on how this app is launched
+
+1. Docker image is used from tiffhuff/pyreconstruct:0.0.1
+2. To launch PyReconstruct, a wrapper.sh file is used to specific path to the loader. 
+   This mechanism is needed due to GLIBC version mismatch between host(LoneStar 6) and the debian 11 container running PyReconstruct.
+   The loader from host is always used and it cannot load version 2.29 and above libraries needed by QT used within PyReconstruct. 
+   So, the loader path from container is used to launch PyReconstruct.
+3. To allow for visibility of QT version needed by PyReconstruct and remaining libraries needed, LD_LIBRARY_PATH is set in the wrapper script.

--- a/applications/pyreconstruct/app.json
+++ b/applications/pyreconstruct/app.json
@@ -1,0 +1,103 @@
+{
+    "id": "pyreconstruct",
+    "version": "0.0.1",
+    "description": "PyReconstruct: A Python initialization of RECONSTRUCT, a 3D Tool for Image Reconstruction on LoneStar 6.",
+    "owner": "${apiUserId}",
+    "enabled": true,
+    "runtime": "SINGULARITY",
+    "runtimeVersion": null,
+    "runtimeOptions": [
+        "SINGULARITY_RUN"
+    ],
+    "containerImage": "docker://taccaci/pyreconstruct:0.0.1",
+    "jobType": "BATCH",
+    "maxJobs": -1,
+    "maxJobsPerUser": -1,
+    "strictFileInputs": true,
+    "jobAttributes": {
+        "description": "PyReconstruct: A Python initialization of RECONSTRUCT, a 3D Tool for Image Reconstruction on LoneStar 6.",
+        "dynamicExecSystem": false,
+        "execSystemConstraints": null,
+        "execSystemId": "ls6",
+        "execSystemExecDir": "${JobWorkingDir}",
+        "execSystemInputDir": "${JobWorkingDir}",
+        "execSystemOutputDir": "${JobWorkingDir}/output",
+        "execSystemLogicalQueue": "development",
+        "archiveSystemId": "cloud.data",
+        "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
+        "archiveOnAppError": true,
+        "isMpi": false,
+        "mpiCmd": null,
+        "cmdPrefix": null,
+        "parameterSet": {
+            "appArgs": [],
+            "containerArgs": [
+                {
+                    "name": "Interactive Session and TACC Module Mounts",
+                    "description": "Mount the required folders in order for TAP, DCV, VNC, and TACC modules to function.",
+                    "inputMode": "FIXED",
+                    "arg": "--bind /bin,/opt/apps,/opt/intel,/run,/share,/lib,/lib64,/usr/bin,/usr/lib/systemd,/usr/libexec,/usr/etc,/usr/include,/usr/share,/usr/sbin,/usr/src,/usr/lib64",
+                    "notes": {
+                        "isHidden": true
+                    }
+                }
+            ],
+            "schedulerOptions": [
+                {
+                    "name": "PyReconstruct TACC Scheduler Profile",
+                    "description": "Scheduler profile for TACC PyReconstruct 0.0.1.",
+                    "inputMode": "FIXED",
+                    "arg": "--tapis-profile PyReconstruct_0.0.1",
+                    "notes": {
+                        "isHidden": true
+                    }
+                },
+                {
+                    "name": "TACC Interactive Session Substrings",
+                    "description": "VNC and DCV sessions require the substrings 'tap_' and '-dcvserver' in the slurm job name in order to function.",
+                    "inputMode": "FIXED",
+                    "arg": "--job-name ${JobName}-dcvserver-tap_",
+                    "notes": {
+                        "isHidden": true
+                    }
+                }
+            ],
+            "envVariables": [                
+                {
+                    "key": "LD_LIBRARY_PATH",
+                    "value": "/lib:/lib64",
+                    "description": "LD_LIBRARY_PATH"
+                },                
+                {
+                    "key": "_XTERM_CMD",
+                    "value": "/app/wrapper.sh",
+                    "description": "Command passed to XTERM, launched within the interactive session."
+                }
+             ],
+            "archiveFilter": {
+                "includes": [],
+                "excludes": [],
+                "includeLaunchFiles": true
+            }
+        },
+        "fileInputs": [],
+        "fileInputArrays": [],
+        "nodeCount": 1,
+        "coresPerNode": 1,
+        "memoryMB": 100,
+        "maxMinutes": 120,
+        "subscriptions": [],
+        "tags": []
+    },
+    "tags": [
+        "portalName: 3DEM,CEP"
+    ],
+    "notes": {
+        "label": "PyReconstruct (LoneStar6)",
+        "helpUrl": "https://github.com/tiffanyhuff/PyReconstructApp",
+        "hideNodeCountAndCoresPerNode": false,
+        "isInteractive": true,
+        "icon": null,
+        "category": "Interactive Analysis"
+    }
+}

--- a/applications/pyreconstruct/app.json
+++ b/applications/pyreconstruct/app.json
@@ -66,7 +66,11 @@
                 {
                     "key": "LD_LIBRARY_PATH",
                     "value": "/lib:/lib64",
-                    "description": "LD_LIBRARY_PATH"
+                    "description": "LD_LIBRARY_PATH",
+                    "inputMode": "FIXED",
+                    "notes": {
+                        "isHidden": true
+                    }
                 },                
                 {
                     "key": "_XTERM_CMD",

--- a/applications/pyreconstruct/app.json
+++ b/applications/pyreconstruct/app.json
@@ -75,7 +75,11 @@
                 {
                     "key": "_XTERM_CMD",
                     "value": "/app/wrapper.sh",
-                    "description": "Command passed to XTERM, launched within the interactive session."
+                    "description": "Command passed to XTERM, launched within the interactive session.",
+                    "inputMode": "FIXED",
+                    "notes": {
+                        "isHidden": true
+                    }
                 }
              ],
             "archiveFilter": {

--- a/applications/pyreconstruct/profile.json
+++ b/applications/pyreconstruct/profile.json
@@ -1,0 +1,16 @@
+{
+    "name": "PyReconstruct_0.0.1",
+    "description": "Modules to load for PyReconstruct",
+    "moduleLoads": [
+        {
+            "modulesToLoad": [
+                "swr",
+                "tacc-apptainer"
+            ],
+            "moduleLoadCommand": "module load"
+        }
+    ],
+    "hiddenOptions": [
+        "MEM"
+    ]
+}

--- a/applications/pyreconstruct/wrapper.sh
+++ b/applications/pyreconstruct/wrapper.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -x
+#uncomment below line to debug
+#export LD_DEBUG=files
+export LD_LIBRARY_PATH="/usr/local/lib/:/usr/local/lib/python3.9/site-packages/PySide6/Qt/lib:$LD_LIBRARY_PATH"
+/usr/local/lib/ld-linux-x86-64.so.2 /usr/local/bin/python /app/pyReconstruct/src/PyReconstruct.py


### PR DESCRIPTION
## Overview
This is PyReconstruct app conversion from Tapis V2 to Tapis V3.
This app runs in LoneStar 6.

## Testing
1. Published this app using : `python3 initialize_tenant.py --tenants=PORTALS --systems=ls6 --apps=pyreconstruct`
2. Job creation
![dev.cep screenshot for app](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/5247600d-0d47-420c-9be3-b0812b303366)

3.  
![Session creation and job running](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/7cfd4bb6-edea-495f-9661-f272032eb699)

4. 
![PyReconstruct app launched](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/13f4131b-e11b-4b00-96d4-c52c02ddab23)


## Notes
This app used a small wrapper script for specific LD_LIBRARY_PATH for PyReconstruct to work in container
