### PR TITLE
Task/wa-34 pyreconstruct dev app in LoneStar 6

### DIFF
--- a/applications/pyreconstruct-dev/Dockerfile
+++ b/applications/pyreconstruct-dev/Dockerfile
@@ -1,0 +1,8 @@
+### pyreconstruct dev image matching PyReconsturct-dev app ###
+FROM eriksf/pyreconstruct:latest
+
+COPY --from=taccaci/interactive-base:1.1.0 /tapis /tapis
+
+ENTRYPOINT [ "/tapis/run.sh" ]
+
+CMD ["1280x800"]

--- a/applications/pyreconstruct-dev/README.md
+++ b/applications/pyreconstruct-dev/README.md
@@ -1,0 +1,6 @@
+# PyReconstruct Dev Tapis V3 app
+
+## Details on how this app is launched
+
+1. Docker image is used from eriksf/pyreconstruct:latest
+2. The special situation with this app is the python module for PyReconstruct is in host path.

--- a/applications/pyreconstruct-dev/app.json
+++ b/applications/pyreconstruct-dev/app.json
@@ -67,6 +67,7 @@
                     "key": "_XTERM_CMD",
                     "value": "python /work/03762/eriksf/public/code/PyReconstruct/src/PyReconstruct.py",
                     "description": "Command passed to XTERM, launched within the interactive session.",
+                    "inputMode": "FIXED",
                     "notes": {
                         "isHidden": true
                     }

--- a/applications/pyreconstruct-dev/app.json
+++ b/applications/pyreconstruct-dev/app.json
@@ -1,0 +1,101 @@
+{
+    "id": "pyreconstruct-dev",
+    "version": "0.0.1",
+    "description": "PyReconstruct Dev: A Python initialization of RECONSTRUCT, a 3D Tool for Image Reconstruction on LoneStar 6. This app uses developer version of image.",
+    "owner": "${apiUserId}",
+    "enabled": true,
+    "runtime": "SINGULARITY",
+    "runtimeVersion": null,
+    "runtimeOptions": [
+        "SINGULARITY_RUN"
+    ],
+    "containerImage": "docker://taccaci/pyreconstruct-dev:0.0.1",
+    "jobType": "BATCH",
+    "maxJobs": -1,
+    "maxJobsPerUser": -1,
+    "strictFileInputs": true,
+    "jobAttributes": {
+        "description": "PyReconstruct Dev: A Python initialization of RECONSTRUCT, a 3D Tool for Image Reconstruction on LoneStar 6. This app uses developer version of image.",
+        "dynamicExecSystem": false,
+        "execSystemConstraints": null,
+        "execSystemId": "ls6",
+        "execSystemExecDir": "${JobWorkingDir}",
+        "execSystemInputDir": "${JobWorkingDir}",
+        "execSystemOutputDir": "${JobWorkingDir}/output",
+        "execSystemLogicalQueue": "development",
+        "archiveSystemId": "cloud.data",
+        "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
+        "archiveOnAppError": true,
+        "isMpi": false,
+        "mpiCmd": null,
+        "cmdPrefix": null,
+        "parameterSet": {
+            "appArgs": [],
+            "containerArgs": [
+                {
+                    "name": "Interactive Session and TACC Module Mounts",
+                    "description": "Mount the required folders in order for TAP, DCV, VNC, and TACC modules to function.",
+                    "inputMode": "FIXED",
+                    "arg": "--bind /bin,/opt/apps,/opt/intel,/run,/share,/lib,/lib64,/usr/bin,/usr/lib/systemd,/usr/libexec,/usr/etc,/usr/include,/usr/share,/usr/sbin,/usr/src,/usr/lib64",
+                    "notes": {
+                        "isHidden": true
+                    }
+                }
+            ],
+            "schedulerOptions": [
+                {
+                    "name": "PyReconstruct Dev TACC Scheduler Profile",
+                    "description": "Scheduler profile for TACC PyReconstruct Dev 0.0.1.",
+                    "inputMode": "FIXED",
+                    "arg": "--tapis-profile PyReconstruct-dev_0.0.1",
+                    "notes": {
+                        "isHidden": true
+                    }
+                },
+                {
+                    "name": "TACC Interactive Session Substrings",
+                    "description": "VNC and DCV sessions require the substrings 'tap_' and '-dcvserver' in the slurm job name in order to function.",
+                    "inputMode": "FIXED",
+                    "arg": "--job-name ${JobName}-dcvserver-tap_",
+                    "notes": {
+                        "isHidden": true
+                    }
+                }
+            ],
+            "envVariables": [
+                {
+                    "key": "_XTERM_CMD",
+                    "value": "python /work/03762/eriksf/public/code/PyReconstruct/src/PyReconstruct.py",
+                    "description": "Command passed to XTERM, launched within the interactive session.",
+                    "notes": {
+                        "isHidden": true
+                    }
+                }
+             ],
+            "archiveFilter": {
+                "includes": [],
+                "excludes": [],
+                "includeLaunchFiles": true
+            }
+        },
+        "fileInputs": [],
+        "fileInputArrays": [],
+        "nodeCount": 1,
+        "coresPerNode": 1,
+        "memoryMB": 100,
+        "maxMinutes": 120,
+        "subscriptions": [],
+        "tags": []
+    },
+    "tags": [
+        "portalName: 3DEM,CEP"
+    ],
+    "notes": {
+        "label": "PyReconstruct Dev (LoneStar6)",
+        "helpUrl": "https://github.com/eriksf/PyReconstructApp",
+        "hideNodeCountAndCoresPerNode": false,
+        "isInteractive": true,
+        "icon": null,
+        "category": "Interactive Analysis"
+    }
+}

--- a/applications/pyreconstruct-dev/profile.json
+++ b/applications/pyreconstruct-dev/profile.json
@@ -1,0 +1,16 @@
+{
+    "name": "PyReconstruct-dev_0.0.1",
+    "description": "Modules to load for PyReconstruct-dev",
+    "moduleLoads": [
+        {
+            "modulesToLoad": [
+                "swr",
+                "tacc-apptainer"
+            ],
+            "moduleLoadCommand": "module load"
+        }
+    ],
+    "hiddenOptions": [
+        "MEM"
+    ]
+}

--- a/initialize_tenant.py
+++ b/initialize_tenant.py
@@ -127,6 +127,7 @@ def main():
                     'napari-ls6',
                     'paraview',
                     'pyreconstruct',
+                    'pyreconstruct-dev',
                     'qgis',
                 ]
 


### PR DESCRIPTION
# Overview
This is a dev version of PyReconstruct.
This is how the app was executed in tapis-v2:
` 'singularity exec --nv docker://eriksf/pyreconstruct:latest python /work/03762/eriksf/public/code/PyReconstruct/src/PyReconstruct.py'`

# Task
https://jira.tacc.utexas.edu/browse/WA-34 

# Testing
1. Publish app `python3 initialize_tenant.py --tenants=PORTALS --systems=ls6 --apps=pyreconstruct-dev`
2. go to dev.cep and launch app:
![Application Page](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/715566ca-4146-42cc-89d9-b467d384ce95)

3. Job session is ready
![Job creation successful](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/4fd47733-4fa6-4777-953e-638ff0f64cdb)

4. PyReconstruct dev version available  
![Screenshot 2023-08-10 at 4 15 14 PM](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/3dc08d6c-8338-48e3-8c9d-e096aaf0128f)
