### PR TITLE
Bug/WA-69: Output folder adjustment for OpenSees apps

### DIFF
--- a/applications/opensees-mp/opensees-mp-3.5.0/app.json
+++ b/applications/opensees-mp/opensees-mp-3.5.0/app.json
@@ -1,7 +1,7 @@
 {
     "id": "opensees-mp-v35",
     "version": "0.0.1",
-    "description": "An application template for version 3.5.0 of OpenSees MP",
+    "description": "OpenSeesMP is an OpenSees interpreter intended for high performance computers for performing finite element simulations with parameteric studies and very large models on parallel machines. OpenSeesMP requires understanding of parallel processing and the capabilities to write parallel scripts.",
     "owner": "${apiUserId}",
     "enabled": true,
     "runtime": "SINGULARITY",
@@ -19,7 +19,7 @@
         "execSystemId": "frontera",
         "execSystemExecDir": "${JobWorkingDir}",
         "execSystemInputDir": "${JobWorkingDir}",
-        "execSystemOutputDir": "${JobWorkingDir}/output",
+        "execSystemOutputDir": "${JobWorkingDir}",
         "execSystemLogicalQueue": "development",
         "archiveSystemId": "cloud.data",
         "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
@@ -45,7 +45,8 @@
                     }
                 },
                 {
-                    "name": "input1",
+                    "name": "TCL Script",
+                    "description": "The filename only of the OpenSees TCL script to execute. This file should reside in the Input Directory specified.",
                     "arg": "Example.tcl",
                     "inputMode": "REQUIRED"
                 }

--- a/applications/opensees-sp/opensees-sp-3.5.0/app.json
+++ b/applications/opensees-sp/opensees-sp-3.5.0/app.json
@@ -19,7 +19,7 @@
         "execSystemId": "frontera",
         "execSystemExecDir": "${JobWorkingDir}",
         "execSystemInputDir": "${JobWorkingDir}",
-        "execSystemOutputDir": "${JobWorkingDir}/output",
+        "execSystemOutputDir": "${JobWorkingDir}",
         "execSystemLogicalQueue": "development",
         "archiveSystemId": "cloud.data",
         "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
@@ -30,7 +30,6 @@
             "appArgs": [
                 {
                     "name": "mainProgram",
-                    "description": "The directory containing your OpenSees input files as well as your OpenSees TCL script. Click the 'Select Input' button and then select the directory.",
                     "arg": "OpenSeesSP",
                     "inputMode": "FIXED",
                     "notes": {
@@ -69,7 +68,7 @@
         ],
         "fileInputArrays": [],
         "nodeCount": 1,
-        "coresPerNode": 1,
+        "coresPerNode": 4,
         "memoryMB": 100,
         "maxMinutes": 120,
         "subscriptions": [],


### PR DESCRIPTION
### Issue
OpenSees app output files are not copied to archive folder.

### Fix Details
OpenSees apps could have output files which are mixed with input and dependent on how TCL script writes them.
All the output files are part of the input files.

Setting the output folder for tapis to be same as execution directory to allow copying of all output files.

### Tests
* Tested on https://pprd.utrc.tacc.utexas.edu/ 

* OpenSees SP: (1ae66a2e-7b00-4d7b-90ee-abb738017dea-007)
![Screenshot 2023-09-19 at 3 29 32 PM](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/500ac1e7-9d7e-4191-bf7e-1a8b313c6f21)

* OpenSees MP: (b11dd455-1b45-472f-bf7f-2178e99bc6fb-007)
![Screenshot 2023-09-19 at 3 56 57 PM](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/c8f88c71-094a-42c4-8105-95fff5282f39)
![Screenshot 2023-09-19 at 3 57 07 PM](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/817d5411-588a-4d67-aa0b-721b06e8d9ef)

### Note
The side-effect of this is that the input files are also copied. Further analysis is needed on OpenSees on how to separate output to a different folder.
