### PR TITLE
Add LS6 version of OpenSees tapis v3 app

### DIFF
--- a/applications/opensees-mp/opensees-mp-ls6-3.5.1/Readme.MD
+++ b/applications/opensees-mp/opensees-mp-ls6-3.5.1/Readme.MD
@@ -1,0 +1,14 @@
+# OpenSees-MP LoneStar6 version 3.5.1 
+
+This is n application json file for docker image : taccaci/opensees:3.5.1
+
+## Details
+
+The application is non-interactive. Once a job using this app has been submitted, the input files
+provided in the job submission body are automatically staged and processing is done.
+The output can be found in the directory specified in the application definition (*execSystemOutputDir*).
+
+Outputs for OpenSees are generally in .out files. This also dependens on how the input tcl script executes and
+redirects output.
+
+Deploying changes: python3 initialize_tenant.py --tenants=PORTALS --systems=ls6 --apps=opensees-mp/opensees-mp-ls6-3.5.1

--- a/applications/opensees-mp/opensees-mp-ls6-3.5.1/app.json
+++ b/applications/opensees-mp/opensees-mp-ls6-3.5.1/app.json
@@ -79,7 +79,7 @@
         "portalName: CEP"
     ],
     "notes": {
-        "label": "OpenSeesMP (V 3.5.1) LS6",
+        "label": "OpenSeesMP 3.5.1 (Lonestar6)",
         "helpUrl": "https://opensees.berkeley.edu/",
         "hideNodeCountAndCoresPerNode": false,
         "isInteractive": false,

--- a/applications/opensees-mp/opensees-mp-ls6-3.5.1/app.json
+++ b/applications/opensees-mp/opensees-mp-ls6-3.5.1/app.json
@@ -1,0 +1,89 @@
+{
+    "id": "opensees-mp-ls6",
+    "version": "3.5.1",
+    "description": "OpenSeesMP is an OpenSees interpreter intended for high performance computers for performing finite element simulations with parameteric studies and very large models on parallel machines. OpenSeesMP requires understanding of parallel processing and the capabilities to write parallel scripts.",
+    "owner": "${apiUserId}",
+    "enabled": true,
+    "runtime": "SINGULARITY",
+    "runtimeVersion": null,
+    "runtimeOptions": [
+        "SINGULARITY_RUN"
+    ],
+    "containerImage": "docker://taccaci/opensees:3.5.1",
+    "jobType": "BATCH",
+    "maxJobs": -1,
+    "maxJobsPerUser": -1,
+    "strictFileInputs": true,
+    "jobAttributes": {
+        "execSystemConstraints": null,
+        "execSystemId": "ls6",
+        "execSystemExecDir": "${JobWorkingDir}",
+        "execSystemInputDir": "${JobWorkingDir}",
+        "execSystemOutputDir": "${JobWorkingDir}",
+        "execSystemLogicalQueue": "development",
+        "archiveSystemId": "cloud.data",
+        "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
+        "archiveOnAppError": true,
+        "isMpi": true,
+        "mpiCmd": "ibrun",
+        "parameterSet": {
+            "appArgs": [
+                {
+                    "name": "mainProgram",
+                    "arg": "/usr/local/bin/OpenSeesMP",
+                    "inputMode": "FIXED",
+                    "notes": {
+                        "isHidden": true
+                    }
+                },
+                {
+                    "name": "inputRedirection",
+                    "arg": "<",
+                    "inputMode": "FIXED",
+                    "notes": {
+                        "isHidden": true
+                    }
+                },
+                {
+                    "name": "TCL Script",
+                    "description": "The filename only of the OpenSees TCL script to execute. This file should reside in the Input Directory specified.",
+                    "arg": "Example.tcl",
+                    "inputMode": "REQUIRED"
+                }
+            ],
+            "archiveFilter": {
+                "includes": [],
+                "excludes": [],
+                "includeLaunchFiles": true
+            }
+        },
+        "fileInputs": [
+            {
+                "name": "TCL Input Directory",
+                "inputMode": "REQUIRED",
+                "sourceUrl": "tapis://cloud.data/corral/tacc/aci/CEP/community/opensees-mp/examples/smallmp",
+                "targetPath": ".",
+                "description": "TCL input directory that includes the tcl script as well as any other required files. Example input is in tapis://cloud.data/corral/tacc/aci/CEP/community/opensees-mp/examples/smallmp/Example.tcl"
+            }
+        ],
+        "fileInputArrays": [],
+        "nodeCount": 2,
+        "coresPerNode": 1,
+        "memoryMB": 100,
+        "maxMinutes": 120,
+        "subscriptions": [],
+        "tags": []
+    },
+    "tags": [
+        "portalName: UTRC",
+        "portalName: CEP"
+    ],
+    "notes": {
+        "label": "OpenSeesMP (V 3.5.1) LS6",
+        "helpUrl": "https://opensees.berkeley.edu/",
+        "hideNodeCountAndCoresPerNode": false,
+        "isInteractive": false,
+        "icon": null,
+        "category": "Simulation"
+    }
+}

--- a/applications/opensees-sp/opensees-sp-ls6-3.5.1/Readme.MD
+++ b/applications/opensees-sp/opensees-sp-ls6-3.5.1/Readme.MD
@@ -1,0 +1,14 @@
+# OpenSees-SP LoneStar6 version 3.5.1 
+
+This is an application json file for docker image : taccaci/opensees:3.5.1
+
+## Details
+
+The application is non-interactive. Once a job using this app has been submitted, the input files
+provided in the job submission body are automatically staged and processing is done.
+The output can be found in the directory specified in the application definition (*execSystemOutputDir*).
+
+Outputs for OpenSees are generally in .out files. This also dependens on how the input tcl script executes and
+redirects output.
+
+Deploying application: python3 initialize_tenant.py --tenants=PORTALS --systems=ls6 --apps=opensees-sp/opensees-sp-ls6-3.5.1

--- a/applications/opensees-sp/opensees-sp-ls6-3.5.1/app.json
+++ b/applications/opensees-sp/opensees-sp-ls6-3.5.1/app.json
@@ -1,0 +1,89 @@
+{
+    "id": "opensees-sp-ls6",
+    "version": "3.5.1",
+    "description": "OpenSeesSP 3.5 is an OpenSees interpreter intended for high performance computers for performing finite element simulations of very large models on parallel machines. OpenSeesSP is easy to use even with limited knowledge about parallel computing. It only requires minimal changes to input scripts to make them consistent with the parallel process logic.",
+    "owner": "${apiUserId}",
+    "enabled": true,
+    "runtime": "SINGULARITY",
+    "runtimeVersion": null,
+    "runtimeOptions": [
+        "SINGULARITY_RUN"
+    ],
+    "containerImage": "docker://taccaci/opensees:3.5.1",
+    "jobType": "BATCH",
+    "maxJobs": -1,
+    "maxJobsPerUser": -1,
+    "strictFileInputs": true,
+    "jobAttributes": {
+        "execSystemConstraints": null,
+        "execSystemId": "ls6",
+        "execSystemExecDir": "${JobWorkingDir}",
+        "execSystemInputDir": "${JobWorkingDir}",
+        "execSystemOutputDir": "${JobWorkingDir}",
+        "execSystemLogicalQueue": "development",
+        "archiveSystemId": "cloud.data",
+        "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
+        "archiveOnAppError": true,
+        "isMpi": true,
+        "mpiCmd": "ibrun",
+        "parameterSet": {
+            "appArgs": [
+                {
+                    "name": "mainProgram",
+                    "arg": "/usr/local/bin/OpenSeesSP",
+                    "inputMode": "FIXED",
+                    "notes": {
+                        "isHidden": true
+                    }
+                },
+                {
+                    "name": "inputRedirection",
+                    "arg": "<",
+                    "inputMode": "FIXED",
+                    "notes": {
+                        "isHidden": true
+                    }
+                },
+                {
+                    "name": "TCL Script",
+                    "description": "The filename only of the OpenSees TCL script to execute. This file should reside in the Input Directory specified.",
+                    "arg": "Example.tcl",
+                    "inputMode": "REQUIRED"
+                }
+            ],
+            "archiveFilter": {
+                "includes": [],
+                "excludes": [],
+                "includeLaunchFiles": true
+            }
+        },
+        "fileInputs": [
+            {
+                "name": "TCL Input Directory",
+                "inputMode": "REQUIRED",
+                "sourceUrl": "tapis://cloud.data/corral/tacc/aci/CEP/community/opensees-sp/examples/smallsp",
+                "targetPath": ".",
+                "description": "TCL input directory that includes the tcl script as well as any other required files. Example input is in tapis://cloud.data/corral/tacc/aci/CEP/community/opensees-sp/examples/smallsp/Example.tcl"
+            }
+        ],
+        "fileInputArrays": [],
+        "nodeCount": 1,
+        "coresPerNode": 4,
+        "memoryMB": 100,
+        "maxMinutes": 120,
+        "subscriptions": [],
+        "tags": []
+    },
+    "tags": [
+        "portalName: UTRC",
+        "portalName: CEP"
+    ],
+    "notes": {
+        "label": "OpenSeesSP LS6 (V 3.5.1)",
+        "helpUrl": "https://opensees.berkeley.edu/",
+        "hideNodeCountAndCoresPerNode": false,
+        "isInteractive": false,
+        "icon": null,
+        "category": "Simulation"
+    }
+}

--- a/applications/opensees-sp/opensees-sp-ls6-3.5.1/app.json
+++ b/applications/opensees-sp/opensees-sp-ls6-3.5.1/app.json
@@ -79,7 +79,7 @@
         "portalName: CEP"
     ],
     "notes": {
-        "label": "OpenSeesSP LS6 (V 3.5.1)",
+        "label": "OpenSeesSP 3.5.1 (Lonestar6)",
         "helpUrl": "https://opensees.berkeley.edu/",
         "hideNodeCountAndCoresPerNode": false,
         "isInteractive": false,


### PR DESCRIPTION
## Details
Add LS6 version of the OpenSees app. Use tacc-aci open sees 3.5.1 images

MP app: https://dev.cep.tacc.utexas.edu/workbench/applications/opensees-mp-ls6?appVersion=3.5.1
SP app: https://dev.cep.tacc.utexas.edu/workbench/applications/opensees-sp-ls6?appVersion=3.5.1

## Related
[WA-120](https://jira.tacc.utexas.edu/browse/WA-120)
[WA-121](https://jira.tacc.utexas.edu/browse/WA-121)

## Test results


![Screenshot 2023-11-30 at 9 32 09 AM](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/bbf7c44e-008e-456b-a64f-e8c3f77f4ea7)

OpenSeesSP out file in output folder
![Screenshot 2023-11-30 at 9 32 29 AM](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/a19e47d9-951f-47d4-a62c-fadbb3f875db)

OpenSeesMP out file sample in output folder
![Screenshot 2023-11-30 at 9 33 12 AM](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/630ca8a3-baf3-4676-bc9b-2d470a970edb)

