### PR TITLE
Convert Align Swift to ZIP Runtime

### DIFF
--- a/applications/align-swift/app.json
+++ b/applications/align-swift/app.json
@@ -4,12 +4,10 @@
     "description": "Run an interactive session with the development version of alignEM Swift-ir with Neuroglancer on Lonestar6. Be sure to exit the application when you are finished with the session or any files saved will not be archived with the job.",
     "owner": "${apiUserId}",
     "enabled": true,
-    "runtime": "SINGULARITY",
+    "runtime": "ZIP",
     "runtimeVersion": null,
-    "runtimeOptions": [
-        "SINGULARITY_RUN"
-    ],
-    "containerImage": "docker://alpine:3",
+    "runtimeOptions": null,
+    "containerImage": "tapis://cloud.data/corral/tacc/aci/CEP/applications/v3/alignem_swift_ng_dev/alignem_swift_app.zip",
     "jobType": "BATCH",
     "maxJobs": -1,
     "maxJobsPerUser": -1,
@@ -28,17 +26,9 @@
         "archiveOnAppError": true,
         "isMpi": false,
         "mpiCmd": null,
-        "cmdPrefix": "source tapisjob.env;source alignem_swift_ng_dev/run.sh;",
+        "cmdPrefix": null,
         "parameterSet": {
             "appArgs": [
-                {
-                    "name": "launchParameters",
-                    "arg": "echo 'Job is done.'",
-                    "inputMode": "FIXED",
-                    "notes": {
-                        "isHidden": true
-                    }
-                }
             ],
             "schedulerOptions": [
                 {
@@ -67,17 +57,6 @@
                 "includeLaunchFiles": true
             }
         },
-        "fileInputs": [
-            {
-                "name": "AlignEM-Swift NG Dev input files",
-                "inputMode": "REQUIRED",
-                "sourceUrl": "tapis://cloud.data/corral/tacc/aci/CEP/applications/v3/alignem_swift_ng_dev",
-                "targetPath": "*",
-                "notes": {
-                    "isHidden": true
-                }
-            }
-        ],
         "fileInputArrays": [],
         "nodeCount": 1,
         "coresPerNode": 1,

--- a/initialize_tenant.py
+++ b/initialize_tenant.py
@@ -94,6 +94,8 @@ def main():
                         help='Comma separated list of systems. Paramater only applies for single tenant case')
     parser.add_argument('-a', '--apps',
                         help='Comma separated list of apps. Paramater only applies for single tenant case')
+    parser.add_argument('-d', '--dev', action='store_false', default=False,
+                        help='Uses Dev Specs when enabled')
     args = parser.parse_args()
 
     if args.tenants:
@@ -144,7 +146,7 @@ def main():
 
         for credentials in TAPIS_CLIENTS.get(tenant_name, []):
             print(f"provisioning tenant: {credentials['base_url']}")
-            client = get_client(**credentials)
+            client = get_client(args.dev, **credentials)
             provision(client, systems, apps, args)
 
 

--- a/utils/client.py
+++ b/utils/client.py
@@ -1,5 +1,5 @@
 from tapipy.tapis import Tapis
 
 
-def get_client(**credentials):
-    return Tapis(**credentials, download_latest_specs=True)
+def get_client(use_dev_specs, **credentials):
+    return Tapis(**credentials, download_latest_specs=True, resource_set='dev') if use_dev_specs else Tapis(**credentials, download_latest_specs=True)


### PR DESCRIPTION
### Overview
Convert Align Swift app from singularity runtime to zip runtime.

Align Swift container could not be built to use on TACC HPC systems with DCV. There are conflicts with libraries needed by DCV and ones needed by Align Swift. To overcome this, the cmdPrefix workaround was used previously with a no-op like container.

With ZIP runtime available now, Align Swift can stop using cmdPrefix workaround and move to ZIP runtime.

### Details
1) Adjust app.json
   - runtime attribute is now ZIP.
   - runtimeOptions is not needed.
   - containerImage is tapis url path to the zip file.
   - fileInput is not needed since containerImage attribute picks up the file directly.
2) ZIP file
   - create alignem_swift_app.zip file in /corral/tacc/aci/CEP/applications/v3/alignem_swift_ng_dev
2) Provisioning script changes:
   - This feature is still in develop branch, so use resource_set='dev' to pick up dev OpenApi Spec.

### Testing
1) Provisioning
```
> python3 initialize_tenant.py -d --tenants=PORTALS --systems=ls6 --apps=align-swift
provisioning tenant: https://portals.develop.tapis.io
profile already exists: tacc-apptainer
system already exists: ls6
system updated: ls6
profile already exists: AlignEM_SwiftNG_Dev_0.0.8u1
app updated: alignem_swiftng_dev
```

2) Portal Testing 
Check the job is submitted, interactive session can be connected.
![Screenshot 2024-01-22 at 9 30 34 AM](https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/5709dbf1-6b51-41b3-b8e7-7bb6610c57c1)


3) HPC system tapisjob.sh file
```
#SBATCH --account TACC-ACI
#SBATCH --job-name alignem_swift_app.zip
#SBATCH --nodes 1
#SBATCH --ntasks 1
#SBATCH --output /scratch/09478/cyemparala/tapis/2d1451c2-6b81-4e79-b5d2-2973a76ba71c-007/output/tapisjob.out
#SBATCH --partition development
#SBATCH --time 10

module load impi/19.0.9
module load intel/19.1.1
module load swr/21.2.5
module load fftw3/3.3.10
module load tacc-apptainer

# Issue launch command for application executable.
# Format: nohup ./tapisjob_app.sh > tapisjob.out 2>&1 &

# Export Tapis and user defined environment variables.
export $(cat ./tapisjob.env | xargs)

# Launch app executable.
./tapisjob_app.sh > /scratch/09478/cyemparala/tapis/2d1451c2-6b81-4e79-b5d2-2973a76ba71c-007/output/tapisjob.out 2>&1
```