### PR TITLE
WA-174: cloud.data execution system and app to set ACLs on files owned by tg458981

### DIFF
--- a/applications/setfacl-corral/app.json
+++ b/applications/setfacl-corral/app.json
@@ -1,0 +1,89 @@
+{
+  "id": "setfacl-corral-tg458981",
+  "version": "0.0.1",
+  "description": "Add/Remove ACLs on a directory",
+  "owner": "${apiUserId}",
+  "enabled": true,
+  "runtime": "ZIP",
+  "runtimeVersion": null,
+  "runtimeOptions": null,
+  "containerImage": "tapis://cloud.data/corral/tacc/aci/CEP/applications/v3/setfacl-corral-tg458981/v001/setfacl-corral-tg458981_v001.zip",
+  "jobType": "FORK",
+  "maxJobs": -1,
+  "maxJobsPerUser": -1,
+  "strictFileInputs": true,
+  "jobAttributes": {
+    "description": "",
+    "dynamicExecSystem": false,
+    "execSystemConstraints": null,
+    "execSystemId": "cloud.data.exec.tg458981",
+    "execSystemExecDir": "${JobWorkingDir}",
+    "execSystemInputDir": "${JobWorkingDir}",
+    "execSystemOutputDir": "${JobWorkingDir}/output",
+    "execSystemLogicalQueue": "small",
+    "archiveSystemId": "cloud.data",
+    "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
+    "archiveOnAppError": true,
+    "isMpi": false,
+    "mpiCmd": null,
+    "cmdPrefix": null,
+    "parameterSet": {
+      "appArgs": [],
+      "containerArgs": [],
+      "schedulerOptions": [],
+      "envVariables": [
+        {
+          "key": "username",
+          "value": "On",
+          "description": "TACC username of user to have ACLs set for",
+          "inputMode": "REQUIRED",
+          "notes": {
+            "label": "username"
+          }
+        },
+        {
+          "key": "directory",
+          "description": "Path on cloud.data.tacc.utexas.edu on which to set ACLs",
+          "inputMode": "REQUIRED",
+          "notes": {
+            "label": "directory"
+          }
+        },
+        {
+          "key": "action",
+          "value": "add",
+          "description": "Action to perform. Either 'add' to add ACLs or 'remove' to remove ACLs",
+          "inputMode": "REQUIRED",
+          "notes": {
+            "label": "action",
+            "enum_values": [
+              {
+                "Add": "add"
+              },
+              {
+                "Remove": "remove"
+              }
+            ]
+          }
+        }
+      ],
+      "archiveFilter": {
+        "includes": ["inputDirectory"],
+        "excludes": [],
+        "includeLaunchFiles": true
+      }
+    },
+    "fileInputs": [],
+    "fileInputArrays": [],
+    "nodeCount": 1,
+    "coresPerNode": 56,
+    "memoryMB": 192,
+    "maxMinutes": 120,
+    "subscriptions": [],
+    "tags": []
+  },
+  "tags": ["portalName: DesignSafe"],
+  "notes": {
+    "label": "setfacls cloud.data"
+  }
+}

--- a/applications/setfacl-corral/app.json
+++ b/applications/setfacl-corral/app.json
@@ -34,7 +34,6 @@
       "envVariables": [
         {
           "key": "username",
-          "value": "On",
           "description": "TACC username of user to have ACLs set for",
           "inputMode": "REQUIRED",
           "notes": {
@@ -68,7 +67,7 @@
         }
       ],
       "archiveFilter": {
-        "includes": ["inputDirectory"],
+        "includes": [],
         "excludes": [],
         "includeLaunchFiles": true
       }

--- a/applications/setfacl-corral/job.json
+++ b/applications/setfacl-corral/job.json
@@ -1,0 +1,26 @@
+{
+  "name": "test-job-setfacl-corral-tg458981",
+  "appId": "setfacl-corral-tg458981",
+  "appVersion": "0.0.1",
+  "description": "Example submission for app setfacl-corral-tg458981",
+  "fileInputs": [],
+  "parameterSet": {
+    "appArgs": [],
+    "schedulerOptions": [],
+    "envVariables": [
+      {
+        "key": "username",
+        "value": "testuser"
+      },
+      {
+        "key": "directory",
+        "value": "/path/to/file"
+      },
+      {
+        "key": "action",
+        "value": "add"
+      }
+    ]
+  },
+  "tags": ["portalName:designsafe"]
+}

--- a/applications/setfacl-corral/tapisjob_app.sh
+++ b/applications/setfacl-corral/tapisjob_app.sh
@@ -1,0 +1,16 @@
+set -x
+
+USER_ID=$(id -u ${username})
+echo "user id: $USER_ID"
+
+if [ "${action}" == "add" ];
+then
+    echo "Running: setfacl -R -m d:u:${USER_ID}:rwX,u:${USER_ID}:rwX ${directory}"
+    setfacl -R -m d:u:${USER_ID}:rwX,u:${USER_ID}:rwX ${directory}
+else
+    if [ "${action}" == "remove" ];
+    then
+        echo "Running: setfacl -R -x d:u:${USER_ID},u:${USER_ID} ${directory}"
+        setfacl -R -x d:u:${USER_ID},u:${USER_ID} ${directory}
+    fi
+fi

--- a/systems/cloud.data.exec.tg458981.json
+++ b/systems/cloud.data.exec.tg458981.json
@@ -1,0 +1,36 @@
+{
+  "isPublic": false,
+  "isDynamicEffectiveUser": false,
+  "id": "cloud.data.exec.tg458981",
+  "description": "System for running jobs on cloud.data",
+  "systemType": "LINUX",
+  "host": "cloud.data.tacc.utexas.edu",
+  "effectiveUserId": "tg458981",
+  "defaultAuthnMethod": "PKI_KEYS",
+  "authnCredential": {
+    "privateKey": "CHANGEME",
+    "publicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0RRA//9Xt5i5E8a4WmcJ7f+q1/GkIVN9hLhtECnwt6/0pMrY+fTo/keHvFJAOVlufcXjMVYb+iJichDjWcVnG4pJbRtTVCk8ahxkG99zvS3K1ln+hY/5EuzuhSlJAWPdjs+PbUCNSHwCkG5vVVpK7X/L8fQXs7Pg4QdbGdhcqy4qTL4BPm8qSrIgIo2SDlu1mkfgL0aypTwnrTIhQA2ohSZ3Q6ozhkTOkAPwu3vUNEoAEbCWD11+aJEWeFW8yzu8/XxbhGARSE6xW/73H9UYxphLUqHE8x8xuZWpNqWixx4YXw0UmKa4FwRkpz+pIs8srxN+/h4TJtl7wJO7Udl47"
+  },
+  "rootDir": "/",
+  "port": 22,
+  "canExec": true,
+  "canRunBatch": false,
+  "enableCmdPrefix": true,
+  "jobRuntimes": [
+    {
+      "runtimeType": "SINGULARITY",
+      "version": null
+    }
+  ],
+  "jobWorkingDir": "HOST_EVAL($HOME)/tapis/${JobUUID}",
+  "jobEnvVariables": [],
+  "jobMaxJobs": -1,
+  "jobMaxJobsPerUser": -1,
+  "batchScheduler": "SLURM",
+  "batchLogicalQueues": [],
+  "batchDefaultLogicalQueue": "normal",
+  "batchSchedulerProfile": "tacc-apptainer",
+  "jobCapabilities": [],
+  "tags": [],
+  "notes": {}
+}


### PR DESCRIPTION
- Add an execution system on cloud.data.tacc.utexas.edu with a static effective user of `tg458981`.
- Add an app that uses this system to set ACLs on files owned by `tg458981` (e.g. DesignSafe projects).

The app/exec system are private and should only be used with`wma_prtl` credentials. To test, use the `job.json` file as a template and replace the environment values with real users/paths on cloud.data.