### PR TITLE
Design Safe and Tapis V3: QGIS Express App

### DIFF
--- a/applications/qgis-express/README.md
+++ b/applications/qgis-express/README.md
@@ -1,0 +1,10 @@
+### QGIS Binary build instructions:
+
+1. On wma-dcv-01 system, sudo as root.
+2. Follow the instructions for ubuntu image version: https://github.com/qgis/QGIS/blob/final-3_36_2/INSTALL.md
+3. Note the version is 3.36.2
+4. setup cmake to use /opt/qgis/3.36 folder as install folder.
+5. Use startup.py for qgis, this is similar to agave version in designsafe.
+
+### Sample data:
+ There is sample data in /corral-repl/tacc/aci/CEP/community/app_examples/qgis/

--- a/applications/qgis-express/app.json
+++ b/applications/qgis-express/app.json
@@ -1,0 +1,61 @@
+{
+    "id": "qgis_express",
+    "version": "3.36.0",
+    "description": "Run an interactive QGIS desktop session on VM.",
+    "owner": "${apiUserId}",
+    "enabled": true,
+    "runtime": "ZIP",
+    "runtimeVersion": null,
+    "runtimeOptions": null,
+    "containerImage": "tapis://cloud.data/corral/tacc/aci/CEP/applications/v3/qgis_express/qgis_express.zip",
+    "jobType": "FORK",
+    "maxJobs": -1,
+    "maxJobsPerUser": -1,
+    "strictFileInputs": true,
+    "jobAttributes": {
+        "description": "",
+        "dynamicExecSystem": false,
+        "execSystemConstraints": null,
+        "execSystemId": "wma-dcv-01",
+        "execSystemExecDir": "${JobWorkingDir}",
+        "execSystemInputDir": "${JobWorkingDir}",
+        "execSystemOutputDir": "${JobWorkingDir}/output",
+        "execSystemLogicalQueue": "development",
+        "archiveSystemId": "cloud.data",
+        "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
+        "archiveOnAppError": true,
+        "isMpi": false,
+        "mpiCmd": null,
+        "cmdPrefix": null,
+        "parameterSet": {
+            "appArgs": [],
+            "schedulerOptions": [
+            ],
+            "envVariables": [],
+            "archiveFilter": {
+                "includes": [],
+                "excludes": [],
+                "includeLaunchFiles": true
+            }
+        },
+        "fileInputArrays": [],
+        "nodeCount": 1,
+        "coresPerNode": 1,
+        "memoryMB": 256000,
+        "maxMinutes": 1440,
+        "subscriptions": [],
+        "tags": []
+    },
+    "tags": [
+        "portalName: CEP",
+        "portalName: DesignSafe"
+    ],
+    "notes": {
+        "label": "QGIS (VM)",
+        "helpUrl": "https://qgis.org/en/docs/index.html",
+        "hideNodeCountAndCoresPerNode": true,
+        "icon": null,
+        "category": "Data Processing",
+        "isInteractive": true
+    }
+}

--- a/applications/qgis-express/startup.py
+++ b/applications/qgis-express/startup.py
@@ -1,0 +1,10 @@
+from qgis.core import QgsExpressionContextUtils
+from qgis.utils import iface
+
+
+def customize():
+    version = QgsExpressionContextUtils.globalScope().variable('qgis_version')
+    title = iface.mainWindow().windowTitle()
+    iface.mainWindow().setWindowTitle('{} | {}'.format(title, version))
+
+iface.initializationCompleted.connect(customize)

--- a/applications/qgis-express/tapisjob_app.sh
+++ b/applications/qgis-express/tapisjob_app.sh
@@ -1,0 +1,65 @@
+set -x
+echo "TACC: job $_tapisJobUUID execution at: `date`"
+
+# confirm DCV server is alive
+DCV_SERVER_UP=`systemctl is-active dcvserver`
+if [ $DCV_SERVER_UP != "active" ]; then
+  echo "TACC:"
+  echo "TACC: ERROR - could not confirm dcvserver active, systemctl returned '$DCV_SERVER_UP'"
+  echo "TACC: ERROR - Please submit a consulting ticket at the TACC user portal"
+  echo "TACC: ERROR - https://portal.tacc.utexas.edu/tacc-consulting/-/consult/tickets/create"
+  echo "TACC:"
+  echo "TACC: job $_tapisJobUUID execution finished at: `date`"
+  exit 1
+fi
+
+# Run this script on session startup
+DCV_STARTUP="/tmp/dcv-startup-${_tapisJobUUID}"
+DCV_HANDLE="${_tapisJobUUID}-session"
+cat <<- EOF > $DCV_STARTUP
+#!/bin/sh
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/qgis/3.36/lib
+/opt/qgis/3.36/bin/qgis --noversioncheck --profiles-path ~/.qgis --code /opt/qgis/3.36/startup.py
+
+dcv close-session ${DCV_HANDLE}
+EOF
+chmod a+rx $DCV_STARTUP
+
+# create DCV session for this job
+dcv create-session --owner ${_tapisJobOwner} --init ${DCV_STARTUP} $DCV_HANDLE
+if ! `dcv list-sessions | grep -q ${_tapisJobUUID}`; then
+  echo "TACC:"
+  echo "TACC: WARNING - could not find a DCV session for this job"
+  echo "TACC: WARNING - This could be because all DCV licenses are in use."
+  echo "TACC: WARNING - Failing over to VNC session."
+  echo "TACC: "
+  echo "TACC: If you rarely receive a DCV session using this script, "
+  echo "TACC: please submit a consulting ticket at the TACC user portal:"
+  echo "TACC: https://portal.tacc.utexas.edu/tacc-consulting/-/consult/tickets/create"
+  echo "TACC: "
+  echo "TACC: job $_tapisJobUUID execution finished at: `date`"
+  exit 1
+fi
+
+LOCAL_PORT="8443"  # default DCV port
+
+# Webhook callback url for job ready notification
+# (notifications sent to INTERACTIVE_WEBHOOK_URL (i.e. https://3dem.org/webhooks/interactive/))`
+INTERACTIVE_WEBHOOK_URL="${_INTERACTIVE_WEBHOOK_URL}"
+
+#connect to DCV session on VM
+curl -k --data "event_type=interactive_session_ready&address=https://wma-dcv-01.tacc.utexas.edu:${LOCAL_PORT}/#${DCV_HANDLE}&owner=${_tapisJobOwner}&job_uuid=${_tapisJobUUID}" $INTERACTIVE_WEBHOOK_URL &
+
+echo "TACC: Your DCV session is now running!"
+echo "TACC: Connect to your session at: https://wma-dcv-01.tacc.utexas.edu:${LOCAL_PORT}/#${DCV_HANDLE}"
+
+# Keep script running while dcv session is active
+while dcv list-sessions | grep -q ${DCV_HANDLE}; do
+  sleep 5;
+done
+echo "TACC: DCV session has been closed."
+
+# remove X11 sockets
+find /tmp/.X11-unix -user $USER -exec rm -f '{}' \;
+
+echo "TACC: job $_tapisJobUUID execution finished at: `date`"


### PR DESCRIPTION
### Changes
This is qgis desktop installed via manual build steps listed in [qgis github ](https://github.com/qgis/QGIS/blob/final-3_36_2/INSTALL.md). And binary installed to /opt

using apt-get, we cannot install to /opt. Moving binary to /opt after install is resulting in auth error in qgis. Building binary was not difficult, took about an hour and the steps are clear in qgis site.

### Related Links
[WA-163](https://tacc-main.atlassian.net/browse/WA-163)


### Testing
1. Submit a job at : https://dev.cep.tacc.utexas.edu/workbench/applications/qgis_express
2. Open Session from jobs history.
3. QGIS opens and window is adjustable to any size.
4. No errors (red banners) shown in UI.

#### Connection Button visible
<img width="864" alt="Screenshot 2024-04-22 at 11 50 40 AM" src="https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/554f2eed-3cea-4a91-a3f9-7c8c5863e498">

#### QGIS app launches in DCV
<img width="1802" alt="Screenshot 2024-04-24 at 8 11 27 AM" src="https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/76e9d3e3-d590-4031-b84a-36b1045023ac">

#### Directory listing shows corral
<img width="239" alt="Screenshot 2024-04-24 at 8 11 57 AM" src="https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/1c4f55de-b016-41a8-9638-f83577f939cc">


### Pending tasks/questions:
1. Should we add a soft link to /corral to user's home directory?
2. Add /corral-repl to wma-dcv-01
3. When tapis job is finished when job time limit is reached, tapis app script is still running. Needs debugging (will open a follow up task).