### PR TITLE
DesignSafe: indicate if a system is userData

### DIFF
--- a/systems/designsafe/designsafe.storage.default.json
+++ b/systems/designsafe/designsafe.storage.default.json
@@ -10,6 +10,7 @@
     "canExec": false,
     "notes": {
         "label": "My Data",
-        "keyservice": true
+        "keyservice": true,
+        "isMyData": true
     }
 }

--- a/systems/designsafe/designsafe.storage.frontera.work.json
+++ b/systems/designsafe/designsafe.storage.frontera.work.json
@@ -10,6 +10,7 @@
     "canExec": false,
     "notes": {
         "label": "HPC Work",
-        "keyservice": true
+        "keyservice": true,
+        "isMyData": true
     }
 }

--- a/systems/designsafe/designsafe.storage.work.json
+++ b/systems/designsafe/designsafe.storage.work.json
@@ -10,6 +10,7 @@
     "canExec": false,
     "notes": {
         "label": "HPC Work",
-        "keyservice": true
+        "keyservice": true,
+        "isMyData": true
     }
 }


### PR DESCRIPTION
There is no easy way to know if a storage system is private or public.
If isMyData is true, then the retrieval scheme is private and username is added to the path for retrieval
Otherwise, scheme is public and username is not added to the path for retrieval.