### PR TITLE
Use LXDE for matlab and qgis express

### DIFF
--- a/applications/matlab-express/tapisjob_app.sh
+++ b/applications/matlab-express/tapisjob_app.sh
@@ -24,8 +24,16 @@ fi
 # Run this script on session startup
 DCV_STARTUP="/tmp/dcv-startup-${_tapisJobUUID}"
 DCV_HANDLE="${_tapisJobUUID}-session"
-cat <<- EOF > $DCV_STARTUP
-#!/bin/sh
+
+cat << 'EOF' > $DCV_STARTUP
+#!/bin/bash
+cleanup() {
+    kill $LXDE_PID
+}
+trap cleanup EXIT
+lxsession &
+LXDE_PID=$!
+sleep 5
 xterm -geometry 80x24+100+100 -e "/opt/MATLAB/R2022b/bin/matlab -c 10280@matlab.shared.utexas.edu"
 dcv close-session ${DCV_HANDLE}
 EOF

--- a/applications/qgis-express/tapisjob_app.sh
+++ b/applications/qgis-express/tapisjob_app.sh
@@ -25,7 +25,14 @@ fi
 DCV_STARTUP="/tmp/dcv-startup-${_tapisJobUUID}"
 DCV_HANDLE="${_tapisJobUUID}-session"
 cat <<- EOF > $DCV_STARTUP
-#!/bin/sh
+#!/bin/bash
+cleanup() {
+    kill $LXDE_PID
+}
+trap cleanup EXIT
+lxsession &
+LXDE_PID=$!
+sleep 5
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/qgis/3.36/lib
 /opt/qgis/3.36/bin/qgis --noversioncheck --profiles-path ~/.qgis --code /opt/qgis/3.36/startup.py || exit 1
 


### PR DESCRIPTION
Steps:

1) sudo apt-get install lxde
2) start lxsession in dcv init script.


Pending issues:
1) some times the title bar close button is non responsive, because app menu -> exit works well.

Testing:
1) Launch qgis express
<img width="2519" alt="Screenshot 2024-06-14 at 11 05 52 AM" src="https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/fe15a52b-7d27-4c02-a4b9-cff00d7a81f9">

2) Launch matlab express
<img width="2376" alt="Screenshot 2024-06-14 at 11 13 56 AM" src="https://github.com/TACC/WMA-Tapis-Templates/assets/2568355/c2438d6f-9fde-46bb-8dfa-74bbded9cbe0">

