### PR TITLE
task/WA-284: Potree Viewer

### DIFF
--- a/applications/potree-viewer/Dockerfile
+++ b/applications/potree-viewer/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx
+
+RUN mkdir /data
+
+COPY ./default.template /etc/nginx/conf.d/default.template
+#COPY ./nginx.conf /etc/nginx/nginx.conf
+
+VOLUME /data

--- a/applications/potree-viewer/app.json
+++ b/applications/potree-viewer/app.json
@@ -32,7 +32,8 @@
             "schedulerOptions": [],
             "envVariables": [],
             "archiveFilter": {
-                "includeLaunchFiles": true
+                "excludes": ["build", "libs"],
+                "includeLaunchFiles": false
             }
         },
         "fileInputs": [

--- a/applications/potree-viewer/app.json
+++ b/applications/potree-viewer/app.json
@@ -1,0 +1,69 @@
+{
+    "id": "potree-viewer",
+    "version": "1.8.2",
+    "description": "View pointclouds in Potree format.",
+    "owner": "${apiUserId}",
+    "enabled": true,
+    "runtime": "ZIP",
+    "runtimeVersion": null,
+    "runtimeOptions": null,
+    "containerImage": "tapis://cloud.data/corral/tacc/aci/CEP/applications/v3/potree-viewer/potree-viewer.zip",
+    "jobType": "FORK",
+    "maxJobs": -1,
+    "maxJobsPerUser": -1,
+    "strictFileInputs": false,
+    "jobAttributes": {
+        "description": "",
+        "dynamicExecSystem": false,
+        "execSystemConstraints": null,
+        "execSystemId": "wma-exec-01",
+        "execSystemExecDir": "${JobWorkingDir}",
+        "execSystemInputDir": "${JobWorkingDir}",
+        "execSystemOutputDir": "${JobWorkingDir}",
+        "execSystemLogicalQueue": "development",
+        "archiveSystemId": "cloud.data",
+        "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
+        "archiveOnAppError": true,
+        "isMpi": false,
+        "mpiCmd": null,
+        "cmdPrefix": null,
+        "parameterSet": {
+            "appArgs": [],
+            "schedulerOptions": [],
+            "envVariables": [],
+            "archiveFilter": {
+                "includeLaunchFiles": true
+            }
+        },
+        "fileInputs": [
+            {
+                "name": "Input file/folder",
+                "description": "File/folder to view in Potree. You can drag the link from the Data Browser on the left, or click the 'Select Input' button and then select the input.",
+                "inputMode": "REQUIRED",
+                "autoMountLocal": true,
+                "sourceUrl": null,
+                "targetPath": ".",
+                "envKey": "viewerInput"
+            }
+        ],
+        "fileInputArrays": [],
+        "nodeCount": 1,
+        "coresPerNode": 1,
+        "memoryMB": 256000,
+        "maxMinutes": 1440,
+        "subscriptions": [],
+        "tags": []
+    },
+    "tags": [
+        "portalName: CEP",
+        "portalName: DesignSafe"
+    ],
+    "notes": {
+        "label": "Potree Viewer (VM)",
+        "helpUrl": "https://github.com/potree/potree/",
+        "hideNodeCountAndCoresPerNode": true,
+        "icon": "Potree",
+        "category": "Visualization",
+        "isInteractive": true
+    }
+}

--- a/applications/potree-viewer/default.template
+++ b/applications/potree-viewer/default.template
@@ -1,0 +1,10 @@
+server {
+    listen              ${LOGIN_PORT} ssl;
+    ssl_certificate     /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+    ssl_protocols       TLSv1.2;
+    location / {
+        root   /data;
+        index  index.html index.htm;
+    }
+}

--- a/applications/potree-viewer/tapisjob_app.sh
+++ b/applications/potree-viewer/tapisjob_app.sh
@@ -36,8 +36,6 @@ apptainer instance run \
 
 # Webhook callback url for job ready notification
 # (notifications sent to INTERACTIVE_WEBHOOK_URL (i.e. https://3dem.org/webhooks/interactive/))`
-INTERACTIVE_WEBHOOK_URL="${_INTERACTIVE_WEBHOOK_URL}"
-
 #connect to interactive session on VM
 curl -k --data "event_type=interactive_session_ready&address=https://wma-exec-01.tacc.utexas.edu:${LOGIN_PORT}&owner=${_tapisJobOwner}&job_uuid=${_tapisJobUUID}" "${_INTERACTIVE_WEBHOOK_URL}" &
 


### PR DESCRIPTION
## Overview: ##
Converts Potree Viewer DS app to run in Tapis v3

## PR Status: ##

* [X] Ready.
* [ ] Work in Progress.
* [ ] Hold.

## Related Jira tickets: ##

* [WA-284](https://tacc-main.atlassian.net/browse/WA-284)

## Summary of Changes: ##
- Created a new App Definition and tapisjob_app file to work with Potree viewer 1.8.2 and the wma-exec-01 VM
- Includes nginx config for secure browser connection to VM port + Dockerfile to use nginx base docker image

## Testing Steps: ##
1. Submit a job at https://dev.cep.tacc.utexas.edu/workbench/applications/potree-viewer with example folder at Community data/potree/potree-viewer
2. Confirm job submits successfully and sends a webhook to connect to viewer session
3. Open session and confirm program opens in new tab as shown below


## UI Photos:
![image](https://github.com/user-attachments/assets/b27d2806-cb4d-49dd-aff5-ed7b1cdd231e)

## Notes: ##
Archiving is currently not functioning correctly for this app, hoping for some feedback on why that might be.