### PR TITLE
Allow "batch" modification of ACLs.

### DIFF
--- a/applications/setfacl-corral/tapisjob_app.sh
+++ b/applications/setfacl-corral/tapisjob_app.sh
@@ -1,16 +1,38 @@
+#!/bin/bash
+
 set -x
 
-USER_ID=$(id -u ${username})
-echo "user id: $USER_ID"
+# username is either an individual username or comma-separated list
+IFS=',' read -ra USERNAMES <<< ${username}
+
+ACL_ADD_COMMANDS=()
+ACL_REMOVE_COMMANDS=()
+for delimitedUser in $USERNAMES;
+    do
+        USER_ID=$(id -u ${delimitedUser})
+        echo "user id: $USER_ID"
+        ACL_ADD_COMMANDS+=("d:u:${USER_ID}:rwX,u:${USER_ID}:rwX")
+        ACL_REMOVE_COMMANDS+=("d:u:${USER_ID},u:${USER_ID}")
+    done
+
+ACL_ADD_STRING=$(IFS=","; echo "${ACL_ADD_COMMANDS[*]}")
+ACL_REMOVE_STRING=$(IFS=","; echo "${ACL_REMOVE_COMMANDS[*]}")
+
 
 if [ "${action}" == "add" ];
 then
-    echo "Running: setfacl -R -m d:u:${USER_ID}:rwX,u:${USER_ID}:rwX ${directory}"
-    setfacl -R -m d:u:${USER_ID}:rwX,u:${USER_ID}:rwX ${directory}
-else
-    if [ "${action}" == "remove" ];
-    then
-        echo "Running: setfacl -R -x d:u:${USER_ID},u:${USER_ID} ${directory}"
-        setfacl -R -x d:u:${USER_ID},u:${USER_ID} ${directory}
-    fi
+    echo "Running: setfacl -R -m ${ACL_ADD_STRING} ${directory}"
+    setfacl -R -m ${ACL_ADD_STRING} ${directory}
+fi
+
+if [ "${action}" == "remove" ];
+then
+    echo "Running: setfacl -R -x ${ACL_REMOVE_STRING} ${directory}"
+    setfacl -R -x ${ACL_REMOVE_STRING} ${directory}
+fi
+
+if [ "${action}" == "dryrun" ];
+then
+    echo "ACL add command: setfacl -R -m ${ACL_ADD_STRING} ${directory}"
+    echo "ACL remove command: setfacl -R -x ${ACL_REMOVE_STRING} ${directory}"
 fi


### PR DESCRIPTION
With this adjustment to the ACL modification script, ACLs can be set for multiple users by providing a comma-separated list as the "user" argument. If a single username is passed, the app should run exactly the same as before.

To test, save the script as `acl_test.sh` and run the following command on your personal machine:
```
username="root" action="dryrun" directory="test"  bash acl_test.sh
```

You should get the following outputs: 
```
+ echo 'ACL add command: setfacl -R -m d:u:0:rwX,u:0:rwX test'
ACL add command: setfacl -R -m d:u:0:rwX,u:0:rwX test
+ echo 'ACL remove command: setfacl -R -x d:u:0,u:0 test'
ACL remove command: setfacl -R -x d:u:0,u:0 test
```