### PR TITLE
WP-710: OpenSees Interactive adjustments for app launch

### DIFF
--- a/applications/opensees-interactive/app.json
+++ b/applications/opensees-interactive/app.json
@@ -60,7 +60,7 @@
         },
         "fileInputs": [],
         "fileInputArrays": [],
-        "maxMinutes": 1440,
+        "maxMinutes": 2880,
         "subscriptions": [],
         "tags": []
     },

--- a/applications/opensees-interactive/app.json
+++ b/applications/opensees-interactive/app.json
@@ -60,7 +60,7 @@
         },
         "fileInputs": [],
         "fileInputArrays": [],
-        "maxMinutes": 2880,
+        "maxMinutes": 1440,
         "subscriptions": [],
         "tags": []
     },
@@ -72,6 +72,7 @@
         "label": "Interactive VM for OpenSees - v3.7.0",
         "helpUrl": "https://www.designsafe-ci.org/rw/user-guides/tools-applications/simulation/opensees/",
         "hideNodeCountAndCoresPerNode": true,
+        "hideMaxMinutes": true,
         "isInteractive": true,
         "icon": "OpenSees",
         "category": "Simulation"


### PR DESCRIPTION
## Changes
* hideMaxMinutes notes for OpenSees.
* Set maxMinutes which is the default to 1440 (24 hours instead of 48 hours).

## Related

* [WP-710](https://tacc-main.atlassian.net/browse/WP-710)
