### PR TITLE
WA-345: Potree viewer with basic auth

### DIFF
--- a/applications/potree-viewer/Dockerfile
+++ b/applications/potree-viewer/Dockerfile
@@ -1,6 +1,7 @@
 FROM nginx:stable
 
-RUN mkdir /data
+RUN apt-get update && apt-get install -y apache2-utils && \
+    mkdir /data
 
 COPY ./default.template /etc/nginx/conf.d/default.template
 

--- a/applications/potree-viewer/default.template
+++ b/applications/potree-viewer/default.template
@@ -4,6 +4,8 @@ server {
     ssl_certificate_key /etc/nginx/ssl/nginx.key;
     ssl_protocols       TLSv1.2;
     location / {
+        auth_basic "Restricted Access";
+        auth_basic_user_file /etc/nginx/.htpasswd;
         root   /data;
         index  index.html index.htm;
     }


### PR DESCRIPTION
### Changes
* Generate password.
* Setup htpasswd file in nginx container
* append message to notify portal

### Related
[WA-345](https://tacc-main.atlassian.net/browse/WA-345)

### Testing
1. Launch https://www.designsafe-ci.org/workspace/potree-viewer?appVersion=1.8.2.
2. Use potree data from https://www.designsafe-ci.org/data/browser/tapis/designsafe.storage.community/%2Fapp_examples%2Fpotree%2Fpotree-converter to convert.
3. Then copy the output files to your data files storage and then open potree viewer.

Connect UI shows: 
<img width="640" alt="Screenshot 2024-10-31 at 1 04 45 PM" src="https://github.com/user-attachments/assets/07a63e47-e7ad-401b-90d4-1e40836c410a">

Clicking connect leads to:
<img width="483" alt="Screenshot 2024-10-31 at 1 04 28 PM" src="https://github.com/user-attachments/assets/1c0f2203-4857-4f9c-8c98-6bc4d377f6e2">

