### PR TITLE
task/WC-15: Add app for archiving Digitalrocks publications

### DIFF
--- a/applications/digitalrocks-archive-publication/app.json
+++ b/applications/digitalrocks-archive-publication/app.json
@@ -1,0 +1,73 @@
+{
+  "id": "digitalrocks-archive-publication",
+  "version": "0.0.1",
+  "description": "ZIP DigitalRocks publication data and metadata",
+  "owner": "${apiUserId}",
+  "enabled": true,
+  "runtime": "ZIP",
+  "runtimeVersion": null,
+  "runtimeOptions": null,
+  "containerImage": "tapis://cloud.data/corral/tacc/aci/CEP/applications/v3/digitalrocks-archive-publication/v1/digitalrocks-archive-publication.zip",
+  "jobType": "FORK",
+  "maxJobs": -1,
+  "maxJobsPerUser": -1,
+  "strictFileInputs": true,
+  "jobAttributes": {
+    "description": "",
+    "dynamicExecSystem": false,
+    "execSystemConstraints": null,
+    "execSystemId": "cloud.data.exec.wma_prtl",
+    "execSystemExecDir": "${JobWorkingDir}",
+    "execSystemInputDir": "${JobWorkingDir}",
+    "execSystemOutputDir": "${JobWorkingDir}/output",
+    "execSystemLogicalQueue": "development",
+    "archiveSystemId": "cloud.data",
+    "archiveSystemDir": "HOST_EVAL($HOME)/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
+    "archiveOnAppError": true,
+    "isMpi": false,
+    "mpiCmd": null,
+    "cmdPrefix": null,
+    "parameterSet": {
+      "appArgs": [],
+      "containerArgs": [],
+      "schedulerOptions": [],
+      "envVariables": [
+        {
+          "key": "publishedRootDir",
+          "description": "Root directory for publications. Archives will be saved in ${publishedRootDir}/archive",
+          "inputMode": "REQUIRED",
+          "notes": {
+            "label": "publishedRootDir"
+          }
+        },
+        {
+          "key": "projectId",
+          "description": "Project ID, e.g. DRP-1234. The data to be archived should be at ${publishedRootDir}/${projectId}",
+          "inputMode": "REQUIRED",
+          "notes": {
+            "label": "projectId"
+          }
+        }
+      ],
+      "archiveFilter": {
+        "includes": [],
+        "excludes": [],
+        "includeLaunchFiles": true
+      }
+    },
+    "fileInputs": [],
+    "fileInputArrays": [],
+    "nodeCount": 1,
+    "coresPerNode": 56,
+    "memoryMB": 192000,
+    "maxMinutes": 120,
+    "subscriptions": [],
+    "tags": []
+  },
+  "tags": [
+    "portalName: DRP"
+  ],
+  "notes": {
+    "label": "digitalrocks-archive-publication"
+  }
+}

--- a/applications/digitalrocks-archive-publication/job.json
+++ b/applications/digitalrocks-archive-publication/job.json
@@ -1,0 +1,23 @@
+{
+    "name": "test-job-digitalrocks-archive-publication",
+    "appId": "digitalrocks-archive-publication",
+    "appVersion": "0.0.1",
+    "description": "Example submission for app digitalrocks-archive-publication",
+    "fileInputs": [],
+    "parameterSet": {
+      "appArgs": [],
+      "schedulerOptions": [],
+      "envVariables": [
+        {
+          "key": "publishedRootDir",
+          "value": "/corral-repl/utexas/OTH21076/data_pprd/published"
+        },
+        {
+          "key": "projectId",
+          "value": "DRP-PPRD-16"
+        }
+      ]
+    },
+    "tags": ["portalName:digitalrocks"]
+  }
+  

--- a/applications/digitalrocks-archive-publication/job.json
+++ b/applications/digitalrocks-archive-publication/job.json
@@ -20,4 +20,3 @@
     },
     "tags": ["portalName:digitalrocks"]
   }
-  

--- a/applications/digitalrocks-archive-publication/tapisjob_app.sh
+++ b/applications/digitalrocks-archive-publication/tapisjob_app.sh
@@ -2,6 +2,12 @@
 
 set -x
 
-zip -r ${publishedRootDir}/archive/${projectId}_archive.zip \
-       ${publishedRootDir}/archive/${projectId}_metadata.json \
-       ${publishedRootDir}/${projectId}
+pushd ${publishedRootDir}
+zip -r archive/${projectId}_archive.zip ${projectId}
+
+# Move to archive folder to add metadata JSON at the top level of the archive
+pushd archive
+zip -u ${projectId}_archive.zip ${projectId}_metadata.json \
+
+popd
+popd

--- a/applications/digitalrocks-archive-publication/tapisjob_app.sh
+++ b/applications/digitalrocks-archive-publication/tapisjob_app.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -x
+
+zip -r ${publishedRootDir}/archive/${projectId}_archive.zip \
+       ${publishedRootDir}/archive/${projectId}_metadata.json \
+       ${publishedRootDir}/${projectId}


### PR DESCRIPTION
This is a really simple app that zips a Digitalrocks publication folder together with its metadata so that the full project can be downloaded. Has been tested successfully (job uuid `874651b8-5c1a-447e-8636-83d8f1a553d9-007`)