### PR TITLE
[Digital Porous Media] Set permissions on published files during archival

### DIFF
--- a/applications/digitalrocks-archive-publication/tapisjob_app.sh
+++ b/applications/digitalrocks-archive-publication/tapisjob_app.sh
@@ -12,8 +12,8 @@ zip -r archive/${projectId}/${projectId}_archive.zip ${projectId}
 
 # Move to archive folder to add metadata JSON at the top level of the archive
 pushd archive/${projectId}
-zip -u ${projectId}_archive.zip ${projectId}_metadata.json \
-chmod 755 ${projectId}_archive.zip
+zip -u ${projectId}_archive.zip ${projectId}_metadata.json
+chmod -R 755 ${projectId}_archive.zip
 
 popd
 popd

--- a/applications/digitalrocks-archive-publication/tapisjob_app.sh
+++ b/applications/digitalrocks-archive-publication/tapisjob_app.sh
@@ -3,12 +3,17 @@
 set -x
 
 pushd ${publishedRootDir}
+
+# Ensure that the published files are world-readable
+chmod -R 755 ${projectId}
+
 mkdir -p archive/${projectId}
 zip -r archive/${projectId}/${projectId}_archive.zip ${projectId}
 
 # Move to archive folder to add metadata JSON at the top level of the archive
 pushd archive/${projectId}
 zip -u ${projectId}_archive.zip ${projectId}_metadata.json \
+chmod 755 ${projectId}_archive.zip
 
 popd
 popd


### PR DESCRIPTION
Ensure that published files get 755 permissions (world readable, writable by owner) during the archival process.