### PR TITLE
Pause the script execution until apptainer process is complete

### DIFF
--- a/applications/a2cps/rstudio-secure/wrapper-secure.sh
+++ b/applications/a2cps/rstudio-secure/wrapper-secure.sh
@@ -81,7 +81,9 @@ apptainer instance start \
     --bind ${workdir}/nginx-cache:/var/cache/nginx \
     --bind ${workdir}/nginx.pid:/var/run/nginx.pid \
     --bind $(cat ${TAP_CERTFILE}):/etc/nginx/ssl/session.crt \
-    library://rstijerina/taccapps/nginx:latest nginx
+    library://rstijerina/taccapps/nginx:latest nginx &
+
+wait $!
 
 # Webhook callback url for job ready notification.
 # Notification is sent to _INTERACTIVE_WEBHOOK_URL, e.g. https://3dem.org/webhooks/interactive/

--- a/applications/potree-viewer/tapisjob_app.sh
+++ b/applications/potree-viewer/tapisjob_app.sh
@@ -38,7 +38,9 @@ apptainer instance run \
     --bind /etc/letsencrypt/live/wma-exec-01.tacc.utexas.edu/privkey.pem:/etc/nginx/ssl/nginx.key \
     --env LOGIN_PORT=$LOGIN_PORT \
     docker://taccaci/potree-viewer:1.8.2 $POTREE_INSTANCE_NAME \
-    /bin/bash -c "cp -r /potree/{build,libs} /data/ && htpasswd -bc /etc/nginx/.htpasswd \"$POTREE_USER\" \"$POTREE_PASSWORD\" && envsubst < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+    /bin/bash -c "cp -r /potree/{build,libs} /data/ && htpasswd -bc /etc/nginx/.htpasswd \"$POTREE_USER\" \"$POTREE_PASSWORD\" && envsubst < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'" &
+
+wait $!
 
 # Webhook callback url for job ready notification
 # (notifications sent to INTERACTIVE_WEBHOOK_URL (i.e. https://3dem.org/webhooks/interactive/))`

--- a/applications/rstudio/inputs/wrapper.sh
+++ b/applications/rstudio/inputs/wrapper.sh
@@ -78,7 +78,9 @@ apptainer instance start \
     --bind ${workdir}/nginx-cache:/var/cache/nginx \
     --bind ${workdir}/nginx.pid:/var/run/nginx.pid \
     --bind $(cat ${TAP_CERTFILE}):/etc/nginx/ssl/session.crt \
-    library://rstijerina/taccapps/nginx:latest nginx
+    library://rstijerina/taccapps/nginx:latest nginx &
+
+wait $!
 
 # Webhook callback url for job ready notification.
 # Notification is sent to _INTERACTIVE_WEBHOOK_URL, e.g. https://3dem.org/webhooks/interactive/


### PR DESCRIPTION
Pause the script execution until apptainer process is complete.

This change ensures that the wrapper script waits for the backgrounded Apptainer process to finish before proceeding, which prevents premature exit and potential 502 Bad Gateway errors.

Testing Steps
Execute either RStudio (Frontera) or the Potree Viewer application.

Verify that the application executes successfully.

Confirm that the 502 page error is no longer displayed during the initial startup or execution phase.

https://dev.cep.tacc.utexas.edu/workbench/applications/rstudio?appVersion=4.3
https://dev.cep.tacc.utexas.edu/workbench/applications/potree-viewer?appVersion=1.8.2

<img width="518" height="471" alt="Screenshot 2026-04-06 at 11 02 11 AM" src="https://github.com/user-attachments/assets/2d45295c-4668-43ba-acb9-1e9ffe9577e8" />
