### PR TITLE
Add `python-s3` — general-purpose Python/binary app for DesignSafe on Stampede3

### DIFF
--- a/applications/python/python-s3/Readme.MD
+++ b/applications/python/python-s3/Readme.MD
@@ -1,13 +1,13 @@
 # python — Stampede3
 
-General-purpose Python app for DesignSafe. Runs Python scripts with optional PyLauncher and MPI support, user-supplied pre/post scripts, and a machine-readable run summary.
+General-purpose app for DesignSafe. Runs Python scripts by default or any executable via `BINARY` with optional PyLauncher and MPI support, user-supplied pre/post scripts, and a machine-readable run summary.
 
 Contact: Krishna Kumar (UT Austin)
 
 ## Lifecycle
 
 ```
-setup (modules, pip)  →  PRE_SCRIPT  →  main script  →  POST_SCRIPT
+setup (modules, pip)  →  PRE_SCRIPT  →  main (BINARY, default python3)  →  POST_SCRIPT
 ```
 
 Failure semantics:
@@ -30,6 +30,7 @@ Every job writes `job-summary.json` next to `tapisjob.out` — on success and on
 
 | Variable | Default | Description |
 |---|---|---|
+| `BINARY` | `python3` | Executable for the main run (name on PATH, `./name` in the Input Directory, or absolute path) |
 | `USE_MPI` | `False` | Launch the main script with the MPI launcher |
 | `MPI_LAUNCHER` | `ibrun` | MPI launch command when `USE_MPI=True` (`srun`/`mpirun` on other systems) |
 | `EXTRA_MODULES` | (empty) | Comma-separated TACC modules to load |
@@ -49,19 +50,42 @@ All optional. Empty values are skipped entirely.
 - executable file → run directly
 - anything else → `bash script.sh`
 
-Use the pre-script for domain setup the wrapper deliberately does not bake in (module loads, staging, unzipping bundles, building inputs). Use the post-script for post-processing and cleanup. Set `POST_SCRIPT_REQUIRED=True` when the post-processing output *is* the deliverable (e.g., aggregating a parameter sweep).
+Use the pre-script for domain setup the wrapper deliberately does not bake in (file staging, unzipping bundles, building inputs or binaries). Use the post-script for post-processing and cleanup. Set `POST_SCRIPT_REQUIRED=True` when the post-processing output *is* the deliverable (e.g., aggregating a parameter sweep).
+
+**Scope note:** pre/post scripts run as child processes, so `module load` inside them does **not** carry into the main run. Modules the main run needs (libraries, executables) must go in `EXTRA_MODULES`.
+
+## Custom binaries
+
+`BINARY` accepts three forms, resolved *after* the pre-script (so a pre-script may build or stage the binary), and the job fails before the main run if it can't be found:
+
+- **Name** (no `/`): looked up on PATH after `EXTRA_MODULES` are loaded — e.g. `BINARY=OpenSeesMP` with `EXTRA_MODULES=opensees,hdf5/1.14.4`
+- **`./name`**: a program shipped inside the Input Directory; the exec bit is restored automatically if staging dropped it
+- **Absolute path**: e.g. `$WORK/apps/mysolver` for your own compiled code
+
+The main run is always `[MPI_LAUNCHER] BINARY INPUTSCRIPT ARGS...`, and the resolved absolute path is recorded in `job-summary.json`.
+
+Example — OpenSeesMP (Tcl), 2 nodes:
+
+```
+BINARY=OpenSeesMP  EXTRA_MODULES=opensees,hdf5/1.14.4  USE_MPI=True
+Input Script: model.tcl
+```
 
 ## OpenSeesPy
 
-Not built in. Use a `PRE_SCRIPT` to set it up:
+Not built in. Load the runtime modules via `EXTRA_MODULES` and copy the TACC build in a `PRE_SCRIPT`:
+
+```
+EXTRA_MODULES=opensees,hdf5/1.14.4   # runtime libraries for the main run
+PRE_SCRIPT=setup.sh
+```
 
 ```bash
 # setup.sh
-module load opensees hdf5/1.14.4
 cp ${TACC_OPENSEES_BIN}/OpenSeesPy.so ./opensees.so
 ```
 
-Then `import opensees as ops` in your main script.
+Then `import opensees as ops` in your main script. (`TACC_OPENSEES_BIN` is set by the opensees module, which `EXTRA_MODULES` loads before the pre-script runs.)
 
 ## job-summary.json
 
@@ -73,7 +97,8 @@ Then `import opensees as ops` in your main script.
   "started": "2026-08-07T10:00:00-05:00",
   "ended": "2026-08-07T10:12:34-05:00",
   "input_script": "run_analysis.py",
-  "command": "ibrun python3 run_analysis.py --npts 2000",
+  "binary": "/opt/apps/python3_12/bin/python3",
+  "command": "/opt/apps/python3_12/bin/python3 run_analysis.py --npts 2000",
   "python_version": "Python 3.12.11",
   "loaded_modules": "…",
   "stages": {

--- a/applications/python/python-s3/Readme.MD
+++ b/applications/python/python-s3/Readme.MD
@@ -1,0 +1,100 @@
+# python — Stampede3
+
+General-purpose Python app for DesignSafe. Runs Python scripts with optional PyLauncher and MPI support, user-supplied pre/post scripts, and a machine-readable run summary.
+
+Contact: Krishna Kumar (UT Austin)
+
+## Lifecycle
+
+```
+setup (modules, pip)  →  PRE_SCRIPT  →  main script  →  POST_SCRIPT
+```
+
+Failure semantics:
+
+- **setup or PRE_SCRIPT fails → job aborts** before the main run (no wasted SUs)
+- **main script fails → job fails**, POST_SCRIPT is skipped
+- **POST_SCRIPT fails → warning only**, unless `POST_SCRIPT_REQUIRED=True`
+
+Every job writes `job-summary.json` next to `tapisjob.out` — on success and on failure — with per-stage exit codes and timings, the exact command run, the Python version, and the loaded modules. Downstream tools (e.g., provenance manifests) can consume it directly.
+
+## Defaults
+
+- Python 3.12 on Stampede3 SKX nodes
+- Serial execution (no MPI)
+- PyLauncher module loaded automatically
+- No pip installs, extra modules, or pre/post scripts unless requested
+- Archives to the submitting user's DesignSafe storage
+
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `USE_MPI` | `False` | Launch the main script with the MPI launcher |
+| `MPI_LAUNCHER` | `ibrun` | MPI launch command when `USE_MPI=True` (`srun`/`mpirun` on other systems) |
+| `EXTRA_MODULES` | (empty) | Comma-separated TACC modules to load |
+| `PIP_PACKAGES` | (empty) | Comma-separated packages to pip install (`--user`) |
+| `PIP_REQUIREMENTS` | (empty) | requirements.txt-style file in the Input Directory; job fails if missing |
+| `PRE_SCRIPT` | (empty) | Script to run before the main script; missing or failing aborts the job |
+| `POST_SCRIPT` | (empty) | Script to run after the main script |
+| `POST_SCRIPT_REQUIRED` | `False` | If `True`, a failing post-script fails the job |
+
+All optional. Empty values are skipped entirely.
+
+## Pre/post scripts
+
+`PRE_SCRIPT` and `POST_SCRIPT` name a file in the Input Directory (or an absolute path on the execution system). How it runs is chosen by extension:
+
+- `*.py` → `python3 script.py`
+- executable file → run directly
+- anything else → `bash script.sh`
+
+Use the pre-script for domain setup the wrapper deliberately does not bake in (module loads, staging, unzipping bundles, building inputs). Use the post-script for post-processing and cleanup. Set `POST_SCRIPT_REQUIRED=True` when the post-processing output *is* the deliverable (e.g., aggregating a parameter sweep).
+
+## OpenSeesPy
+
+Not built in. Use a `PRE_SCRIPT` to set it up:
+
+```bash
+# setup.sh
+module load opensees hdf5/1.14.4
+cp ${TACC_OPENSEES_BIN}/OpenSeesPy.so ./opensees.so
+```
+
+Then `import opensees as ops` in your main script.
+
+## job-summary.json
+
+```json
+{
+  "app_id": "python-s3",
+  "app_version": "1.0.0",
+  "job_uuid": "…",
+  "started": "2026-08-07T10:00:00-05:00",
+  "ended": "2026-08-07T10:12:34-05:00",
+  "input_script": "run_analysis.py",
+  "command": "ibrun python3 run_analysis.py --npts 2000",
+  "python_version": "Python 3.12.11",
+  "loaded_modules": "…",
+  "stages": {
+    "setup": {"seconds": 41},
+    "pre_script": {"script": "setup.sh", "exit_code": 0, "seconds": 3},
+    "main": {"exit_code": 0, "seconds": 702},
+    "post_script": {"script": null, "exit_code": null, "seconds": null}
+  },
+  "exit_code": 0,
+  "total_seconds": 754
+}
+```
+
+`null` means the stage did not run.
+
+## Porting to other systems
+
+The wrapper is system-agnostic: only `app.json` (execution system, queue, archive) and `profile.json` (base modules) change per system, plus the `MPI_LAUNCHER` default. To add e.g. `python-ls6`, copy this directory alongside as `applications/python/python-ls6/` and adjust those two files.
+
+## Deploying
+
+```
+python3 initialize_tenant.py --tenants=DESIGNSAFE --systems=stampede3 --apps=python/python-s3
+```

--- a/applications/python/python-s3/Readme.MD
+++ b/applications/python/python-s3/Readme.MD
@@ -34,13 +34,25 @@ Every job writes `job-summary.json` next to `tapisjob.out` — on success and on
 | `USE_MPI` | `False` | Launch the main script with the MPI launcher |
 | `MPI_LAUNCHER` | `ibrun` | MPI launch command when `USE_MPI=True` (`srun`/`mpirun` on other systems) |
 | `EXTRA_MODULES` | (empty) | Comma-separated TACC modules to load |
-| `PIP_PACKAGES` | (empty) | Comma-separated packages to pip install (`--user`) |
-| `PIP_REQUIREMENTS` | (empty) | requirements.txt-style file in the Input Directory; job fails if missing |
+| `PYTHON_ENV` | (empty) | Path to a persistent virtual environment to use (created if missing, kept after the job) |
+| `PIP_PACKAGES` | (empty) | Comma-separated packages to pip install into the job's Python environment |
+| `PIP_REQUIREMENTS` | (empty) | requirements.txt-style file installed into the job's Python environment; job fails if missing |
 | `PRE_SCRIPT` | (empty) | Script to run before the main script; missing or failing aborts the job |
 | `POST_SCRIPT` | (empty) | Script to run after the main script |
 | `POST_SCRIPT_REQUIRED` | `False` | If `True`, a failing post-script fails the job |
 
 All optional. Empty values are skipped entirely.
+
+## Python environment
+
+Two modes, both created with `--system-site-packages` so the module-provided numpy/scipy/mpi4py stack is inherited:
+
+- **Default (temporary):** when `PIP_PACKAGES` or `PIP_REQUIREMENTS` is set, a throwaway venv (`.job-venv`) is created in the job working directory and deleted on exit — nothing leaks into `$HOME`, no packages carry over between jobs, the archive stays small. No environment is created when neither variable is set.
+- **Persistent (`PYTHON_ENV`):** point at a path such as `$WORK/envs/myproject` to reuse an environment across jobs and skip repeated pip installs. It is created if missing, never deleted, and pip installs (if any) go into it. Prefer `$WORK`/`$SCRATCH` paths; an environment inside the Input Directory would be archived with your results.
+
+Either way the environment is *activated* for the whole job — its `bin/` is prepended to PATH and `VIRTUAL_ENV` is set — so the pre/post scripts, `pip3`, and the main run all resolve into it, and the default `BINARY=python3` resolves to the environment's interpreter by absolute path (which is what each MPI rank under `ibrun` executes). The path used is recorded as `python_env` in `job-summary.json`.
+
+**Caveat:** pip installs pair with the app's default `python3`. If you override `BINARY` to a different Python interpreter by absolute path, it bypasses the environment and will not see the installed packages.
 
 ## Pre/post scripts
 
@@ -98,6 +110,7 @@ Then `import opensees as ops` in your main script. (`TACC_OPENSEES_BIN` is set b
   "ended": "2026-08-07T10:12:34-05:00",
   "input_script": "run_analysis.py",
   "binary": "/opt/apps/python3_12/bin/python3",
+  "python_env": null,
   "command": "/opt/apps/python3_12/bin/python3 run_analysis.py --npts 2000",
   "python_version": "Python 3.12.11",
   "loaded_modules": "…",

--- a/applications/python/python-s3/app.json
+++ b/applications/python/python-s3/app.json
@@ -1,0 +1,167 @@
+{
+  "id": "python-s3",
+  "version": "1.0.0",
+  "description": "General-purpose Python execution on Stampede3 with optional PyLauncher and MPI support, pre/post scripts, and a machine-readable job-summary.json for provenance.",
+  "owner": "${apiUserId}",
+  "enabled": true,
+  "runtime": "ZIP",
+  "containerImage": "tapis://cloud.data/corral/tacc/aci/CEP/applications/v3/python/1.0.0/python.zip",
+  "jobType": "BATCH",
+  "maxJobs": -1,
+  "maxJobsPerUser": -1,
+  "strictFileInputs": true,
+  "jobAttributes": {
+    "execSystemId": "stampede3",
+    "execSystemExecDir": "${JobWorkingDir}",
+    "execSystemInputDir": "${JobWorkingDir}",
+    "execSystemOutputDir": "${JobWorkingDir}",
+    "execSystemLogicalQueue": "skx",
+    "archiveSystemId": "designsafe.storage.default",
+    "archiveSystemDir": "${EffectiveUserId}/tapis-jobs-archive/${JobCreateDate}/${JobName}-${JobUUID}",
+    "archiveOnAppError": true,
+    "isMpi": false,
+    "parameterSet": {
+      "appArgs": [
+        {
+          "name": "Input Script",
+          "description": "Python script to execute. Must be in the Input Directory.",
+          "arg": null,
+          "inputMode": "REQUIRED",
+          "notes": {
+            "inputType": "fileInput"
+          }
+        },
+        {
+          "name": "Arguments",
+          "description": "Optional command-line arguments passed to the script.",
+          "arg": null,
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "notes": {}
+        }
+      ],
+      "containerArgs": [],
+      "schedulerOptions": [
+        {
+          "name": "TACC Scheduler Profile",
+          "description": "Scheduler profile for module loading.",
+          "inputMode": "FIXED",
+          "arg": "--tapis-profile python_default",
+          "notes": {
+            "isHidden": true
+          }
+        },
+        {
+          "name": "TACC Allocation",
+          "description": "TACC allocation to charge.",
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "arg": null,
+          "notes": {}
+        }
+      ],
+      "envVariables": [
+        {
+          "key": "USE_MPI",
+          "value": "False",
+          "inputMode": "INCLUDE_BY_DEFAULT",
+          "description": "Set to True to launch with ibrun for MPI parallelism (mpi4py, OpenSeesMP). False for serial, PyLauncher, or concurrent.futures.",
+          "notes": {
+            "enum_values": [
+              {"False": "Serial execution (default)"},
+              {"True": "MPI parallel (ibrun)"}
+            ]
+          }
+        },
+        {
+          "key": "EXTRA_MODULES",
+          "value": "",
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "description": "Comma-separated TACC modules to load in addition to python. Example: 'opensees,hdf5/1.14.4'.",
+          "notes": {}
+        },
+        {
+          "key": "PIP_PACKAGES",
+          "value": "",
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "description": "Comma-separated Python packages to pip install before the run. Example: 'scipy,h5py'. Skipped if empty.",
+          "notes": {}
+        },
+        {
+          "key": "PIP_REQUIREMENTS",
+          "value": "",
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "description": "requirements.txt-style file in the Input Directory to pip install before the run. Example: 'requirements.txt'. The job fails if the file is missing.",
+          "notes": {}
+        },
+        {
+          "key": "PRE_SCRIPT",
+          "value": "",
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "description": "Script in the Input Directory to run before the main script ('.py' runs via python3, anything else via bash). Use for custom setup (module loads, file staging, OpenSeesPy, etc.). If it is missing or fails, the job aborts before the main run.",
+          "notes": {}
+        },
+        {
+          "key": "POST_SCRIPT",
+          "value": "",
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "description": "Script in the Input Directory to run after the main script ('.py' runs via python3, anything else via bash). Use for post-processing or cleanup. Failure is a warning unless POST_SCRIPT_REQUIRED=True.",
+          "notes": {}
+        },
+        {
+          "key": "POST_SCRIPT_REQUIRED",
+          "value": "False",
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "description": "If True, a failing POST_SCRIPT fails the job. Use when post-processing output is the deliverable (e.g., sweep aggregation).",
+          "notes": {
+            "enum_values": [
+              {"False": "Post-script failure is a warning (default)"},
+              {"True": "Post-script failure fails the job"}
+            ]
+          }
+        },
+        {
+          "key": "MPI_LAUNCHER",
+          "value": "ibrun",
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "description": "MPI launch command used when USE_MPI=True. Default 'ibrun' (TACC). Override for other systems (e.g., 'srun', 'mpirun').",
+          "notes": {}
+        }
+      ],
+      "archiveFilter": {
+        "includes": [],
+        "excludes": ["python.zip"],
+        "includeLaunchFiles": true
+      }
+    },
+    "fileInputs": [
+      {
+        "name": "Input Directory",
+        "inputMode": "REQUIRED",
+        "sourceUrl": null,
+        "targetPath": "inputDirectory",
+        "envKey": "inputDirectory",
+        "description": "Directory containing the Python script and any supporting files.",
+        "notes": {
+          "selectionMode": "directory"
+        }
+      }
+    ],
+    "fileInputArrays": [],
+    "nodeCount": 1,
+    "coresPerNode": 48,
+    "memoryMB": 192000,
+    "maxMinutes": 120,
+    "subscriptions": [],
+    "tags": []
+  },
+  "tags": [
+    "portalName: DesignSafe"
+  ],
+  "notes": {
+    "label": "Python (Stampede3)",
+    "helpUrl": "https://designsafe-ci.github.io/dapi/",
+    "hideNodeCountAndCoresPerNode": false,
+    "isInteractive": false,
+    "icon": "Python",
+    "category": "Simulation"
+  }
+}

--- a/applications/python/python-s3/app.json
+++ b/applications/python/python-s3/app.json
@@ -49,13 +49,6 @@
           "notes": {
             "isHidden": true
           }
-        },
-        {
-          "name": "TACC Allocation",
-          "description": "TACC allocation to charge.",
-          "inputMode": "INCLUDE_ON_DEMAND",
-          "arg": null,
-          "notes": {}
         }
       ],
       "envVariables": [
@@ -86,17 +79,24 @@
           "notes": {}
         },
         {
+          "key": "PYTHON_ENV",
+          "value": "",
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "description": "Path to a Python virtual environment to use for the run (e.g. '$WORK/envs/myproject'). Created with access to the module-provided packages if it does not exist, and kept after the job — reuse it across jobs to skip repeated pip installs. If unset, a temporary per-job environment is created only when pip installs are requested and removed after the job.",
+          "notes": {}
+        },
+        {
           "key": "PIP_PACKAGES",
           "value": "",
           "inputMode": "INCLUDE_ON_DEMAND",
-          "description": "Comma-separated Python packages to pip install before the run. Example: 'scipy,h5py'. Skipped if empty.",
+          "description": "Comma-separated Python packages to pip install before the run into the job's Python environment (temporary per-job venv, or PYTHON_ENV if set). Example: 'scipy,h5py'. Skipped if empty.",
           "notes": {}
         },
         {
           "key": "PIP_REQUIREMENTS",
           "value": "",
           "inputMode": "INCLUDE_ON_DEMAND",
-          "description": "requirements.txt-style file in the Input Directory to pip install before the run. Example: 'requirements.txt'. The job fails if the file is missing.",
+          "description": "requirements.txt-style file in the Input Directory to pip install before the run into the job's Python environment (temporary per-job venv, or PYTHON_ENV if set). Example: 'requirements.txt'. The job fails if the file is missing.",
           "notes": {}
         },
         {
@@ -135,7 +135,7 @@
       ],
       "archiveFilter": {
         "includes": [],
-        "excludes": ["python.zip"],
+        "excludes": ["python.zip", ".job-venv"],
         "includeLaunchFiles": true
       }
     },

--- a/applications/python/python-s3/app.json
+++ b/applications/python/python-s3/app.json
@@ -1,7 +1,7 @@
 {
   "id": "python-s3",
   "version": "1.0.0",
-  "description": "General-purpose Python execution on Stampede3 with optional PyLauncher and MPI support, pre/post scripts, and a machine-readable job-summary.json for provenance.",
+  "description": "General-purpose execution on Stampede3 — Python by default, any binary via BINARY — with optional PyLauncher and MPI support, pre/post scripts, and a machine-readable job-summary.json for provenance.",
   "owner": "${apiUserId}",
   "enabled": true,
   "runtime": "ZIP",
@@ -24,7 +24,7 @@
       "appArgs": [
         {
           "name": "Input Script",
-          "description": "Python script to execute. Must be in the Input Directory.",
+          "description": "Script or input file passed to the binary (default python3, see BINARY). Must be in the Input Directory.",
           "arg": null,
           "inputMode": "REQUIRED",
           "notes": {
@@ -59,6 +59,13 @@
         }
       ],
       "envVariables": [
+        {
+          "key": "BINARY",
+          "value": "python3",
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "description": "Executable for the main run (default python3). Either a name resolved on PATH after EXTRA_MODULES (e.g. 'OpenSeesMP'), './name' for a program inside the Input Directory, or an absolute path on the execution system (e.g. '$WORK/apps/solver'). Resolved after PRE_SCRIPT; the job fails before the run if it cannot be found.",
+          "notes": {}
+        },
         {
           "key": "USE_MPI",
           "value": "False",

--- a/applications/python/python-s3/profile.json
+++ b/applications/python/python-s3/profile.json
@@ -1,0 +1,15 @@
+{
+  "name": "python_default",
+  "description": "Default modules for Python execution on Stampede3",
+  "moduleLoads": [
+    {
+      "modulesToLoad": [
+        "python/3.12.11"
+      ],
+      "moduleLoadCommand": "module load"
+    }
+  ],
+  "hiddenOptions": [
+    "MEM"
+  ]
+}

--- a/applications/python/python-s3/tapisjob_app.sh
+++ b/applications/python/python-s3/tapisjob_app.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+set -euo pipefail
+set -x
+
+# python-s3: general-purpose Python app for DesignSafe (TACC Stampede3)
+#
+# Lifecycle:  setup (modules, pip) -> PRE_SCRIPT -> main script -> POST_SCRIPT
+#
+# Failure semantics:
+#   - setup or PRE_SCRIPT failure aborts before the main run (no wasted SUs)
+#   - main-script failure skips POST_SCRIPT and fails the job
+#   - POST_SCRIPT failure warns only, unless POST_SCRIPT_REQUIRED=True
+#
+# A machine-readable job-summary.json (stage exit codes and timings) is always
+# written next to tapisjob.out, on success and on failure.
+
+export APP_ID="python-s3"
+export APP_VERSION="1.0.0"
+
+INPUTSCRIPT="${1:?missing input script}"
+shift
+
+# Strip path — script must be in inputDirectory
+INPUTSCRIPT="${INPUTSCRIPT##*/}"
+export SUMMARY_INPUTSCRIPT="$INPUTSCRIPT"
+
+ROOT_DIR="$(pwd)"
+export SUMMARY_PATH="${ROOT_DIR}/job-summary.json"
+export STARTED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+JOB_START=$(date +%s)
+
+# Live output in tapisjob.out instead of buffered chunks
+export PYTHONUNBUFFERED=1
+
+# Stage bookkeeping for the summary writer (empty = stage did not run)
+export SETUP_SEC="" PRE_RC="" PRE_SEC="" MAIN_RC="" MAIN_SEC="" POST_RC="" POST_SEC=""
+export SUMMARY_CMD="" SUMMARY_PYTHON="" SUMMARY_MODULES="" OVERALL_RC="" TOTAL_SEC="" ENDED_AT=""
+
+write_summary() {
+  rc=$?
+  export OVERALL_RC=$rc
+  export ENDED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  export TOTAL_SEC=$(( $(date +%s) - JOB_START ))
+  python3 - <<'PYEOF' || echo "WARNING: could not write job-summary.json" >&2
+import json
+import os
+
+
+def num(name):
+    value = os.environ.get(name, "").strip()
+    return int(value) if value else None
+
+
+def script_stage(script_var, rc_var, sec_var):
+    return {
+        "script": os.environ.get(script_var) or None,
+        "exit_code": num(rc_var),
+        "seconds": num(sec_var),
+    }
+
+
+summary = {
+    "app_id": os.environ["APP_ID"],
+    "app_version": os.environ["APP_VERSION"],
+    "job_uuid": os.environ.get("_tapisJobUUID") or None,
+    "hostname": os.uname().nodename,
+    "started": os.environ.get("STARTED_AT"),
+    "ended": os.environ.get("ENDED_AT"),
+    "input_script": os.environ.get("SUMMARY_INPUTSCRIPT"),
+    "command": os.environ.get("SUMMARY_CMD") or None,
+    "python_version": os.environ.get("SUMMARY_PYTHON") or None,
+    "loaded_modules": os.environ.get("SUMMARY_MODULES") or None,
+    "stages": {
+        "setup": {"seconds": num("SETUP_SEC")},
+        "pre_script": script_stage("PRE_SCRIPT", "PRE_RC", "PRE_SEC"),
+        "main": {"exit_code": num("MAIN_RC"), "seconds": num("MAIN_SEC")},
+        "post_script": script_stage("POST_SCRIPT", "POST_RC", "POST_SEC"),
+    },
+    "exit_code": num("OVERALL_RC"),
+    "total_seconds": num("TOTAL_SEC"),
+}
+
+path = os.environ["SUMMARY_PATH"]
+with open(path, "w") as f:
+    json.dump(summary, f, indent=2)
+    f.write("\n")
+print(f"Wrote {path}")
+PYEOF
+}
+trap write_summary EXIT
+
+is_true() {
+  [[ "${1:-}" =~ ^([Tt][Rr][Uu][Ee]|1)$ ]]
+}
+
+# Run a user-supplied script: .py via python3, executables directly, else bash
+run_user_script() {
+  local script="$1"
+  if [[ "$script" != /* ]]; then
+    script="./${script}"
+  fi
+  if [[ ! -f "$script" ]]; then
+    echo "ERROR: script not found: $script" >&2
+    return 127
+  fi
+  case "$script" in
+    *.py)
+      python3 "$script"
+      ;;
+    *)
+      if [[ -x "$script" ]]; then
+        "$script"
+      else
+        bash "$script"
+      fi
+      ;;
+  esac
+}
+
+cd "${inputDirectory:?inputDirectory not set}"
+echo "Working directory: $(pwd)"
+
+# ---------------------------------------------------------------- setup ----
+SETUP_START=$(date +%s)
+
+# --- Extra TACC modules (if any) ---
+if [[ -n "${EXTRA_MODULES:-}" ]]; then
+  IFS=',' read -ra MODS <<< "$EXTRA_MODULES"
+  for mod in "${MODS[@]}"; do
+    mod="$(echo "$mod" | xargs)"
+    if [[ -n "$mod" ]]; then
+      module load "$mod"
+    fi
+  done
+fi
+
+# --- PyLauncher (always available for Python) ---
+module load pylauncher || true
+
+# --- Pip: requirements file (if any) ---
+if [[ -n "${PIP_REQUIREMENTS:-}" ]]; then
+  REQ="${PIP_REQUIREMENTS}"
+  if [[ "$REQ" != /* ]]; then
+    REQ="./${REQ}"
+  fi
+  if [[ ! -f "$REQ" ]]; then
+    echo "ERROR: PIP_REQUIREMENTS file not found: $REQ" >&2
+    exit 66
+  fi
+  pip3 install --user --no-warn-script-location -r "$REQ"
+fi
+
+# --- Pip: package list (if any) ---
+if [[ -n "${PIP_PACKAGES:-}" ]]; then
+  IFS=',' read -ra PKGS <<< "$PIP_PACKAGES"
+  CLEAN_PKGS=()
+  for pkg in "${PKGS[@]}"; do
+    pkg="$(echo "$pkg" | xargs)"
+    if [[ -n "$pkg" ]]; then
+      CLEAN_PKGS+=("$pkg")
+    fi
+  done
+  if [[ ${#CLEAN_PKGS[@]} -gt 0 ]]; then
+    pip3 install --user --no-warn-script-location "${CLEAN_PKGS[@]}"
+  fi
+fi
+
+export SUMMARY_PYTHON="$(python3 -V 2>&1 || true)"
+export SUMMARY_MODULES="$(module list 2>&1 | tr '\n' ' ' || true)"
+export SETUP_SEC=$(( $(date +%s) - SETUP_START ))
+
+# ----------------------------------------------------------- pre-script ----
+if [[ -n "${PRE_SCRIPT:-}" ]]; then
+  T0=$(date +%s)
+  if run_user_script "$PRE_SCRIPT"; then
+    export PRE_RC=0
+  else
+    export PRE_RC=$?
+  fi
+  export PRE_SEC=$(( $(date +%s) - T0 ))
+  if [[ "$PRE_RC" -ne 0 ]]; then
+    echo "ERROR: PRE_SCRIPT '${PRE_SCRIPT}' failed (exit ${PRE_RC}); aborting before main run." >&2
+    exit "$PRE_RC"
+  fi
+fi
+
+# ------------------------------------------------------------------ run ----
+MAIN_CMD=(python3 "$INPUTSCRIPT" "$@")
+if is_true "${USE_MPI:-False}"; then
+  MAIN_CMD=("${MPI_LAUNCHER:-ibrun}" "${MAIN_CMD[@]}")
+fi
+export SUMMARY_CMD="${MAIN_CMD[*]}"
+
+T0=$(date +%s)
+if "${MAIN_CMD[@]}"; then
+  export MAIN_RC=0
+else
+  export MAIN_RC=$?
+fi
+export MAIN_SEC=$(( $(date +%s) - T0 ))
+
+if [[ "$MAIN_RC" -ne 0 ]]; then
+  echo "ERROR: main script exited with status ${MAIN_RC}; skipping POST_SCRIPT." >&2
+  exit "$MAIN_RC"
+fi
+
+# ---------------------------------------------------------- post-script ----
+if [[ -n "${POST_SCRIPT:-}" ]]; then
+  T0=$(date +%s)
+  if run_user_script "$POST_SCRIPT"; then
+    export POST_RC=0
+  else
+    export POST_RC=$?
+  fi
+  export POST_SEC=$(( $(date +%s) - T0 ))
+  if [[ "$POST_RC" -ne 0 ]]; then
+    if is_true "${POST_SCRIPT_REQUIRED:-False}"; then
+      echo "ERROR: POST_SCRIPT '${POST_SCRIPT}' failed (exit ${POST_RC}) and POST_SCRIPT_REQUIRED=True." >&2
+      exit "$POST_RC"
+    fi
+    echo "WARNING: POST_SCRIPT '${POST_SCRIPT}' failed (exit ${POST_RC}); main results are unaffected." >&2
+  fi
+fi
+
+echo "Done."

--- a/applications/python/python-s3/tapisjob_app.sh
+++ b/applications/python/python-s3/tapisjob_app.sh
@@ -34,7 +34,7 @@ export PYTHONUNBUFFERED=1
 
 # Stage bookkeeping for the summary writer (empty = stage did not run)
 export SETUP_SEC="" PRE_RC="" PRE_SEC="" MAIN_RC="" MAIN_SEC="" POST_RC="" POST_SEC=""
-export SUMMARY_CMD="" SUMMARY_PYTHON="" SUMMARY_MODULES="" SUMMARY_BINARY="" OVERALL_RC="" TOTAL_SEC="" ENDED_AT=""
+export SUMMARY_CMD="" SUMMARY_PYTHON="" SUMMARY_MODULES="" SUMMARY_BINARY="" SUMMARY_VENV="" SUMMARY_VENV_TEMP="" OVERALL_RC="" TOTAL_SEC="" ENDED_AT=""
 
 write_summary() {
   rc=$?
@@ -68,6 +68,7 @@ summary = {
     "ended": os.environ.get("ENDED_AT"),
     "input_script": os.environ.get("SUMMARY_INPUTSCRIPT"),
     "binary": os.environ.get("SUMMARY_BINARY") or None,
+    "python_env": os.environ.get("SUMMARY_VENV") or None,
     "command": os.environ.get("SUMMARY_CMD") or None,
     "python_version": os.environ.get("SUMMARY_PYTHON") or None,
     "loaded_modules": os.environ.get("SUMMARY_MODULES") or None,
@@ -87,6 +88,12 @@ with open(path, "w") as f:
     f.write("\n")
 print(f"Wrote {path}")
 PYEOF
+  # Remove the temp per-job venv so it is never archived (summary is written
+  # first). User-provided PYTHON_ENV environments are kept.
+  if [[ "${SUMMARY_VENV_TEMP:-}" == "1" && -n "${SUMMARY_VENV:-}" && -d "${SUMMARY_VENV}" ]]; then
+    rm -rf -- "${SUMMARY_VENV}" || true
+    echo "Removed temp job venv: ${SUMMARY_VENV}"
+  fi
 }
 trap write_summary EXIT
 
@@ -138,6 +145,39 @@ fi
 # --- PyLauncher (always available for Python) ---
 module load pylauncher || true
 
+# --- Python environment ---
+# PYTHON_ENV set: use that environment (created with --system-site-packages if
+#   missing) and KEEP it after the job, so repeat jobs skip reinstalls.
+# PYTHON_ENV unset: create a temp per-job venv only when pip installs are
+#   requested, and remove it on exit so nothing leaks into $HOME or the archive.
+ENV_DIR=""
+if [[ -n "${PYTHON_ENV:-}" ]]; then
+  ENV_DIR="${PYTHON_ENV}"
+  if [[ "$ENV_DIR" != /* ]]; then
+    ENV_DIR="$(pwd)/${ENV_DIR#./}"
+  fi
+  if [[ ! -x "${ENV_DIR}/bin/python3" ]]; then
+    if [[ -e "$ENV_DIR" ]]; then
+      echo "ERROR: PYTHON_ENV '${ENV_DIR}' exists but is not a Python environment (no bin/python3)." >&2
+      exit 65
+    fi
+    echo "PYTHON_ENV not found; creating persistent environment: ${ENV_DIR}"
+    python3 -m venv --system-site-packages "$ENV_DIR"
+  else
+    echo "Reusing Python environment: ${ENV_DIR}"
+  fi
+elif [[ -n "${PIP_REQUIREMENTS:-}" || -n "${PIP_PACKAGES:-}" ]]; then
+  ENV_DIR="${ROOT_DIR}/.job-venv"
+  python3 -m venv --system-site-packages "$ENV_DIR"
+  export SUMMARY_VENV_TEMP="1"
+  echo "Created temp job venv: ${ENV_DIR}"
+fi
+if [[ -n "$ENV_DIR" ]]; then
+  export VIRTUAL_ENV="$ENV_DIR"
+  export PATH="${ENV_DIR}/bin:${PATH}"
+  export SUMMARY_VENV="$ENV_DIR"
+fi
+
 # --- Pip: requirements file (if any) ---
 if [[ -n "${PIP_REQUIREMENTS:-}" ]]; then
   REQ="${PIP_REQUIREMENTS}"
@@ -148,7 +188,7 @@ if [[ -n "${PIP_REQUIREMENTS:-}" ]]; then
     echo "ERROR: PIP_REQUIREMENTS file not found: $REQ" >&2
     exit 66
   fi
-  pip3 install --user --no-warn-script-location -r "$REQ"
+  pip3 install -r "$REQ"
 fi
 
 # --- Pip: package list (if any) ---
@@ -162,7 +202,7 @@ if [[ -n "${PIP_PACKAGES:-}" ]]; then
     fi
   done
   if [[ ${#CLEAN_PKGS[@]} -gt 0 ]]; then
-    pip3 install --user --no-warn-script-location "${CLEAN_PKGS[@]}"
+    pip3 install "${CLEAN_PKGS[@]}"
   fi
 fi
 

--- a/applications/python/python-s3/tapisjob_app.sh
+++ b/applications/python/python-s3/tapisjob_app.sh
@@ -4,7 +4,7 @@ set -x
 
 # python-s3: general-purpose Python app for DesignSafe (TACC Stampede3)
 #
-# Lifecycle:  setup (modules, pip) -> PRE_SCRIPT -> main script -> POST_SCRIPT
+# Lifecycle:  setup (modules, pip) -> PRE_SCRIPT -> main (BINARY, default python3) -> POST_SCRIPT
 #
 # Failure semantics:
 #   - setup or PRE_SCRIPT failure aborts before the main run (no wasted SUs)
@@ -34,7 +34,7 @@ export PYTHONUNBUFFERED=1
 
 # Stage bookkeeping for the summary writer (empty = stage did not run)
 export SETUP_SEC="" PRE_RC="" PRE_SEC="" MAIN_RC="" MAIN_SEC="" POST_RC="" POST_SEC=""
-export SUMMARY_CMD="" SUMMARY_PYTHON="" SUMMARY_MODULES="" OVERALL_RC="" TOTAL_SEC="" ENDED_AT=""
+export SUMMARY_CMD="" SUMMARY_PYTHON="" SUMMARY_MODULES="" SUMMARY_BINARY="" OVERALL_RC="" TOTAL_SEC="" ENDED_AT=""
 
 write_summary() {
   rc=$?
@@ -67,6 +67,7 @@ summary = {
     "started": os.environ.get("STARTED_AT"),
     "ended": os.environ.get("ENDED_AT"),
     "input_script": os.environ.get("SUMMARY_INPUTSCRIPT"),
+    "binary": os.environ.get("SUMMARY_BINARY") or None,
     "command": os.environ.get("SUMMARY_CMD") or None,
     "python_version": os.environ.get("SUMMARY_PYTHON") or None,
     "loaded_modules": os.environ.get("SUMMARY_MODULES") or None,
@@ -184,8 +185,43 @@ if [[ -n "${PRE_SCRIPT:-}" ]]; then
   fi
 fi
 
+# ---------------------------------------------------------- main binary ----
+# Resolved after PRE_SCRIPT so a pre-script may stage or build the binary.
+BINARY="${BINARY:-python3}"
+case "$BINARY" in
+  python|Python|Python3) BINARY="python3" ;;
+esac
+
+RESOLVED_BINARY=""
+if [[ "$BINARY" == */* ]]; then
+  # Path form: absolute, or relative to the Input Directory
+  CAND="$BINARY"
+  if [[ "$CAND" != /* ]]; then
+    CAND="$(pwd)/${CAND#./}"
+  fi
+  if [[ -f "$CAND" && ! -x "$CAND" ]]; then
+    echo "NOTE: adding execute permission to ${CAND} (staging can drop exec bits)"
+    chmod +x "$CAND" || true
+  fi
+  if [[ -x "$CAND" ]]; then
+    RESOLVED_BINARY="$CAND"
+  fi
+else
+  # Name form: resolve on PATH (as set by the profile and EXTRA_MODULES)
+  RESOLVED_BINARY="$(command -v "$BINARY" || true)"
+fi
+
+if [[ -z "$RESOLVED_BINARY" ]]; then
+  echo "ERROR: BINARY '${BINARY}' not found or not executable." >&2
+  echo "HINT: use a module-provided name (add its module to EXTRA_MODULES)," >&2
+  echo "      './name' for a program inside the Input Directory," >&2
+  echo "      or an absolute path such as \$WORK/apps/solver." >&2
+  exit 127
+fi
+export SUMMARY_BINARY="$RESOLVED_BINARY"
+
 # ------------------------------------------------------------------ run ----
-MAIN_CMD=(python3 "$INPUTSCRIPT" "$@")
+MAIN_CMD=("$RESOLVED_BINARY" "$INPUTSCRIPT" "$@")
 if is_true "${USE_MPI:-False}"; then
   MAIN_CMD=("${MPI_LAUNCHER:-ibrun}" "${MAIN_CMD[@]}")
 fi


### PR DESCRIPTION
Adds a general-purpose ZIP-runtime Tapis app that runs a user's Python script
(or any executable) on Stampede3 with a clean, staged lifecycle:

```
setup (modules, pip) -> PRE_SCRIPT -> main (BINARY, default python3) -> POST_SCRIPT
```

One app covers the long tail of workflows that will never get a bespoke app:
post-processing, parameter sweeps (PyLauncher), mpi4py, ML pipelines, OpenSeesPy,
and user-compiled solvers. "New workflow" becomes "new input directory + script"
instead of "new app.json + wrapper + registration."

## Motivation

- Every DesignSafe job must go through a registered Tapis app; without a generic
  one, each new analysis type needs its own app or an SSH/sbatch workaround.
- The community `designsafe-agnostic-app` proved the demand, but it bakes
  OpenSees-specific logic into the wrapper, is deployed from a personal
  `$WORK` path (not version-controlled), and its failure handling is dead code
  under `set -e`. This app keeps the idea and fixes the design.
- Downstream tooling (dapi, the DesignSafe workflow assistant) needs a stable,
  pinnable execution target with machine-readable run records for provenance
  and reproducibility.