### PR TITLE
Add UNZIP_INPUTS to python-s3 so bundled inputs expand before setup, …

### DIFF
--- a/applications/python/python-s3/README.md
+++ b/applications/python/python-s3/README.md
@@ -7,7 +7,7 @@ Contact: Krishna Kumar (UT Austin)
 ## Lifecycle
 
 ```
-setup (modules, pip)  →  PRE_SCRIPT  →  main (BINARY, default python3)  →  POST_SCRIPT
+setup (unzip, modules, pip)  →  PRE_SCRIPT  →  main (BINARY, default python3)  →  POST_SCRIPT
 ```
 
 Failure semantics:
@@ -33,6 +33,7 @@ Every job writes `job-summary.json` next to `tapisjob.out` — on success and on
 | `BINARY` | `python3` | Executable for the main run (name on PATH, `./name` in the Input Directory, or absolute path) |
 | `USE_MPI` | `False` | Launch the main script with the MPI launcher |
 | `MPI_LAUNCHER` | `ibrun` | MPI launch command when `USE_MPI=True` (`srun`/`mpirun` on other systems) |
+| `UNZIP_INPUTS` | (empty) | Comma-separated ZIPs in the Input Directory to expand before anything else runs |
 | `EXTRA_MODULES` | (empty) | Comma-separated TACC modules to load |
 | `PYTHON_ENV` | (empty) | Path to a persistent virtual environment to use (created if missing, kept after the job) |
 | `PIP_PACKAGES` | (empty) | Comma-separated packages to pip install into the job's Python environment |
@@ -42,6 +43,17 @@ Every job writes `job-summary.json` next to `tapisjob.out` — on success and on
 | `POST_SCRIPT_REQUIRED` | `False` | If `True`, a failing post-script fails the job |
 
 All optional. Empty values are skipped entirely.
+
+## Input bundling
+
+Tapis stages each file of a directory input as its own transfer task (roughly 40 seconds per file when the tenant transfer queue is loaded), so an input directory with many small files can spend far longer staging than running. Bundle it client-side and let the wrapper expand it:
+
+```
+Input Directory: contains inputs.zip (and nothing else)
+UNZIP_INPUTS=inputs
+```
+
+The expansion runs before everything else — the pre-script, `PIP_REQUIREMENTS` file, and main script may all live inside the bundle. A listed ZIP that is missing fails the job immediately.
 
 ## Python environment
 

--- a/applications/python/python-s3/app.json
+++ b/applications/python/python-s3/app.json
@@ -79,6 +79,13 @@
           "notes": {}
         },
         {
+          "key": "UNZIP_INPUTS",
+          "value": "",
+          "inputMode": "INCLUDE_ON_DEMAND",
+          "description": "Comma-separated ZIP files in the Input Directory to expand before anything else runs ('.zip' suffix optional). Bundle many small input files into one ZIP so Tapis staging transfers one file instead of one per file. The job fails if a listed ZIP is missing.",
+          "notes": {}
+        },
+        {
           "key": "PYTHON_ENV",
           "value": "",
           "inputMode": "INCLUDE_ON_DEMAND",

--- a/applications/python/python-s3/tapisjob_app.sh
+++ b/applications/python/python-s3/tapisjob_app.sh
@@ -4,7 +4,7 @@ set -x
 
 # python-s3: general-purpose Python app for DesignSafe (TACC Stampede3)
 #
-# Lifecycle:  setup (modules, pip) -> PRE_SCRIPT -> main (BINARY, default python3) -> POST_SCRIPT
+# Lifecycle:  setup (unzip, modules, pip) -> PRE_SCRIPT -> main (BINARY, default python3) -> POST_SCRIPT
 #
 # Failure semantics:
 #   - setup or PRE_SCRIPT failure aborts before the main run (no wasted SUs)
@@ -130,6 +130,30 @@ echo "Working directory: $(pwd)"
 
 # ---------------------------------------------------------------- setup ----
 SETUP_START=$(date +%s)
+
+# --- Expand input bundles first ---
+# Tapis stages each file of a directory input as its own transfer task
+# (~40s/file under tenant load), so many-small-file inputs should be shipped
+# as one ZIP. This runs before everything else because the pre-script,
+# requirements file, and main script may all live inside the bundle.
+if [[ -n "${UNZIP_INPUTS:-}" ]]; then
+  IFS=',' read -ra ZIPS <<< "$UNZIP_INPUTS"
+  for z in "${ZIPS[@]}"; do
+    z="$(echo "$z" | xargs)"
+    if [[ -z "$z" ]]; then
+      continue
+    fi
+    if [[ "$z" != *.zip ]]; then
+      z="${z}.zip"
+    fi
+    if [[ ! -f "$z" ]]; then
+      echo "ERROR: UNZIP_INPUTS entry not found: $z" >&2
+      exit 66
+    fi
+    unzip -o -q "$z"
+    echo "Unzipped: $z"
+  done
+fi
 
 # --- Extra TACC modules (if any) ---
 if [[ -n "${EXTRA_MODULES:-}" ]]; then


### PR DESCRIPTION
…avoiding per-file Tapis staging overhead.

TAPIS transfer overhead issue:

The transfer record shows it isn't startup queueing: staging transaction went created→started in 2.8 s, then spent 10m48s executing 15 transfers ~43 s per file. From reading the tapis-files source, each file in a recursive directory input becomes its own child transfer task, picked up across scheduler ticks (TransfersAssigner backoff up to ~16 s, ChildTaskTransferService scanning on a 5 s fixed delay) on workers shared tenant-wide, so staging time scales with file count, not bytes.
Consistent with that, the same job staged its 1.7 MB app.zip in 20 s.

 As a workaround we now zip inputs client-side and let the app wrapper unzip (the quoFEM wrapper already supports tmpSimCenter.zip). Same job, same inputs:



STAGING_INPUTS │ 10:58  (15 files totaling 23 kb)│ 0:46  (one zip input)
TOTAL | 29:09  (before)│ 16:23 (now)